### PR TITLE
Deprecate intersect and rename to intersection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@
 - Removed deprecated `verbose` parameter in some functions 
 - Rename some files in util that are rather private (#84)
 - Remove long-time deprecated clip_on_tiles parameter in dissolve (#95)
-- Deprecate `gfo.intersect()` to rename to `gfo.intersection()`. Now a 
-  warning is given, in the future `gfo.intersect()` will be removed (#99)
+- Deprecate `gfo.intersect()` for new name `gfo.intersection()` to be 
+  consistend with most other libraries. Now a warning is given, in the future 
+  `gfo.intersect()` will be removed (#99).
 
 ## 0.4.0 (2022-03-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Rename some files in util that are rather private (#84)
 - Remove long-time deprecated clip_on_tiles parameter in dissolve (#95)
 - Deprecate `gfo.intersect()` for new name `gfo.intersection()` to be 
-  consistend with most other libraries. Now a warning is given, in the future 
+  consistent with most other libraries. Now a warning is given, in the future 
   `gfo.intersect()` will be removed (#99).
 
 ## 0.4.0 (2022-03-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Rename some files in util that are rather private (#84)
 - Remove long-time deprecated clip_on_tiles parameter in dissolve (#95)
 - Deprecate `gfo.intersect()` to rename to `gfo.intersection()`. Now a 
-  warning is given, in the future `gfo.intersect()` will be removed (#)
+  warning is given, in the future `gfo.intersect()` will be removed (#99)
 
 ## 0.4.0 (2022-03-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - Removed deprecated `verbose` parameter in some functions 
 - Rename some files in util that are rather private (#84)
 - Remove long-time deprecated clip_on_tiles parameter in dissolve (#95)
+- Deprecate `gfo.intersect()` to rename to `gfo.intersection()`. Now a 
+  warning is given, in the future `gfo.intersect()` will be removed (#)
 
 ## 0.4.0 (2022-03-31)
 

--- a/benchmark/benchmarks/benchmarks_geofileops.py
+++ b/benchmark/benchmarks/benchmarks_geofileops.py
@@ -168,7 +168,7 @@ def clip(tmp_dir: Path) -> RunResult:
     #output_path.unlink()
     return result
 
-def intersect(tmp_dir: Path) -> RunResult:
+def intersection(tmp_dir: Path) -> RunResult:
     # Init
     input1_path = testdata.TestFile.AGRIPRC_2018.get_file(tmp_dir)
     input2_path = testdata.TestFile.AGRIPRC_2019.get_file(tmp_dir)
@@ -184,9 +184,9 @@ def intersect(tmp_dir: Path) -> RunResult:
     result = RunResult(
             package=_get_package(), 
             package_version=_get_version(),
-            operation='intersect', 
+            operation='intersection', 
             secs_taken=(datetime.now()-start_time).total_seconds(),
-            operation_descr="intersect between 2 agri parcel layers BEFL (2*~500.000 polygons)",
+            operation_descr="intersection between 2 agri parcel layers BEFL (2*~500.000 polygons)",
             run_details={"nb_cpu": multiprocessing.cpu_count()})
 
     # Cleanup and return

--- a/benchmark/benchmarks/benchmarks_geofileops.py
+++ b/benchmark/benchmarks/benchmarks_geofileops.py
@@ -176,7 +176,7 @@ def intersect(tmp_dir: Path) -> RunResult:
     # Go!
     start_time = datetime.now()
     output_path = tmp_dir / f"{input1_path.stem}_inters_{input2_path.stem}.gpkg"
-    gfo.intersect(
+    gfo.intersection(
             input1_path=input1_path, 
             input2_path=input2_path, 
             output_path=output_path,

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -69,13 +69,13 @@ More specific features are:
 The full list of operations can be found in the 
 :ref:`API reference<API-reference-two-layers>`.
 
-This is a code example for the intersect operation:
+This is a code example for the intersection operation:
 
 .. code-block:: python
 
     import geofileops as gfo
 
-    gfo.intersect(
+    gfo.intersection(
             input1_path='...',
             input2_path='...',
             output_path='...')

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -8,6 +8,7 @@ import logging.config
 import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
+import warnings
 
 from geofileops.util import _geoops_gpd
 from geofileops.util import _geoops_sql
@@ -1068,6 +1069,41 @@ def intersect(
         batchsize: int = -1,
         verbose: bool = False,
         force: bool = False):
+    
+    warnings.warn("intersect() is deprecated because it was renamed intersection(). Will be removed in a future version", FutureWarning)
+    return intersection(
+            input1_path=input1_path,
+            input2_path=input2_path,
+            output_path=output_path,
+            input1_layer=input1_layer,
+            input1_columns=input1_columns,
+            input1_columns_prefix=input1_columns_prefix,
+            input2_layer=input2_layer,
+            input2_columns=input2_columns,
+            input2_columns_prefix=input2_columns_prefix,
+            output_layer=output_layer,
+            explodecollections=explodecollections,
+            nb_parallel=nb_parallel,
+            batchsize=batchsize,
+            verbose=verbose,
+            force=force)
+
+def intersection(
+        input1_path: Union[str, 'os.PathLike[Any]'],
+        input2_path: Union[str, 'os.PathLike[Any]'],
+        output_path: Union[str, 'os.PathLike[Any]'],
+        input1_layer: Optional[str] = None,
+        input1_columns: Optional[List[str]] = None,
+        input1_columns_prefix: str = 'l1_',
+        input2_layer: Optional[str] = None,
+        input2_columns: Optional[List[str]] = None,
+        input2_columns_prefix: str = 'l2_',
+        output_layer: Optional[str] = None,
+        explodecollections: bool = False,
+        nb_parallel: int = -1,
+        batchsize: int = -1,
+        verbose: bool = False,
+        force: bool = False):
     """
     Calculate the pairwise intersection of alle features in input1 with all 
     features in input2.
@@ -1099,8 +1135,8 @@ def intersect(
         force (bool, optional): overwrite existing output file(s). 
             Defaults to False.
     """
-    logger.info(f"Start intersect between {input1_path} and {input2_path} to {output_path}")
-    return _geoops_sql.intersect(
+    logger.info(f"Start intersection between {input1_path} and {input2_path} to {output_path}")
+    return _geoops_sql.intersection(
             input1_path=Path(input1_path),
             input2_path=Path(input2_path),
             output_path=Path(output_path),

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -550,7 +550,7 @@ def clip(
 
     # Prepare sql template for this operation 
     # Remarks:
-    #   - ST_intersect(geometry , NULL) gives NULL as result! -> hence the CASE 
+    #   - ST_intersection(geometry , NULL) gives NULL as result! -> hence the CASE 
     #   - use of the with instead of an inline view is a lot faster
     #   - WHERE geom IS NOT NULL to evade rows with a NULL geom, they give issues in later operations
     sql_template = f'''
@@ -825,7 +825,7 @@ def export_by_distance(
             verbose=verbose,
             force=force)
 
-def intersect(
+def intersection(
         input1_path: Path,
         input2_path: Path,
         output_path: Path,

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -291,7 +291,7 @@ def basetest_export_by_distance(
     output_gdf = gfo.read_file(output_path)
     assert output_gdf['geometry'][0] is not None
 
-def test_intersect(tmpdir):
+def test_intersection(tmpdir):
     # Prepare test data + run tests
     tmp_dir = Path(tmpdir)
     tmp_dir.mkdir(parents=True, exist_ok=True)
@@ -314,9 +314,9 @@ def test_intersect(tmpdir):
             # Now run test
             output_path = tmp_dir / f"{input1_path.stem}-output{suffix}"
             print(f"Run test for suffix {suffix}, crs_epsg {crs_epsg}")
-            basetest_intersect(input1_path, input2_path, output_path)
+            basetest_intersection(input1_path, input2_path, output_path)
     
-def basetest_intersect(
+def basetest_intersection(
         input1_path: Path, 
         input2_path: Path, 
         output_path: Path):
@@ -514,7 +514,7 @@ def basetest_select_two_layers(
         output_path: Path):
 
     # Prepare query to execute. At the moment this is just the query for the 
-    # intersect() operation.
+    # intersection() operation.
     input1_layer_info = gfo.get_layerinfo(input1_path)
     input2_layer_info = gfo.get_layerinfo(input2_path)
     primitivetype_to_extract = PrimitiveType(min(

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -322,7 +322,7 @@ def basetest_intersect(
         output_path: Path):
 
     # Do operation
-    gfo.intersect(
+    gfo.intersection(
             input1_path=input1_path,
             input2_path=input2_path,
             output_path=output_path,


### PR DESCRIPTION
Deprecate `gfo.intersect()` for new name `gfo.intersection()` to be consistent with most other libraries. Now a warning is given, in the future `gfo.intersect()` will be removed.