### PR TITLE
Add all direct dependencies of geofileops explicitly in setup.py + ci environments

### DIFF
--- a/ci/envs/38-latest-conda-forge.yaml
+++ b/ci/envs/38-latest-conda-forge.yaml
@@ -11,9 +11,9 @@ dependencies:
   - geopandas
   - numpy
   - pandas
+  - psutil
   - pygeos
   - pyproj
-  - psutil
   - shapely
   # testing
   - pytest

--- a/ci/envs/38-latest-conda-forge.yaml
+++ b/ci/envs/38-latest-conda-forge.yaml
@@ -4,19 +4,19 @@ channels:
 dependencies:
   - python=3.8
   - pip
-  #- six
   # required
   - cloudpickle
+  - fiona
+  - gdal
   - geopandas
+  - numpy
+  - pandas
+  - pygeos
   - pyproj
   - psutil
+  - shapely
   # testing
   - pytest
   - pytest-cov
-  # optional
-  - pygeos 
-  # TEMP: workaround until conda-forge fixes the issues with gdal
-  #- zstd
   - pip:
-    #- codecov
     - simplification

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -11,9 +11,9 @@ dependencies:
   - geopandas
   - numpy
   - pandas
+  - psutil
   - pygeos
   - pyproj
-  - psutil
   - shapely
   # testing
   - pytest

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -4,19 +4,19 @@ channels:
 dependencies:
   - python=3.9
   - pip
-  #- six
   # required
   - cloudpickle
+  - fiona
+  - gdal
   - geopandas
+  - numpy
+  - pandas
+  - pygeos
   - pyproj
   - psutil
+  - shapely
   # testing
   - pytest
   - pytest-cov
-  # optional
-  - pygeos 
-  # TEMP: workaround until conda-forge fixes the issues with gdal
-  #- zstd
   - pip:
-    #- codecov
     - simplification

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     url='https://github.com/geofileops/geofileops',
     include_package_data=True,
     packages=setuptools.find_packages(),
-    install_requires=['cloudpickle', 'geopandas>=0.10', 'pygeos', 'pyproj', 'psutil'],
+    install_requires=['cloudpickle', 'gdal', 'geopandas>=0.10', 'pygeos', 'pyproj', 'psutil'],
     extras_require = {
         'full': ['simplification']
     },

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,9 @@ setuptools.setup(
     url="https://github.com/geofileops/geofileops",
     include_package_data=True,
     packages=setuptools.find_packages(),
-    install_requires=["cloudpickle", "fiona", "gdal", "geopandas>=0.10", "pygeos", "pyproj", "psutil", "shapely"],
+    install_requires=[
+            "cloudpickle", "fiona", "gdal", "geopandas>=0.10", "numpy", 
+            "pandas", "pygeos", "pyproj", "psutil", "shapely"],
     extras_require = {
         "full": ["simplification"]
     },

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
             "cloudpickle", "fiona", "gdal", "geopandas>=0.10", "numpy", 
-            "pandas", "pygeos", "pyproj", "psutil", "shapely"],
+            "pandas", "psutil", "pygeos", "pyproj", "shapely"],
     extras_require = {
         "full": ["simplification"]
     },

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,29 @@
 import setuptools
 
-with open('README.md', 'r') as fh:
+with open("README.md", "r") as fh:
     long_description = fh.read()
 
-with open('geofileops/version.txt', mode='r') as file:
+with open("geofileops/version.txt", mode="r") as file:
     version = file.readline()
 
 setuptools.setup(
-    name='geofileops', 
+    name="geofileops", 
     version=version,
-    author='Pieter Roggemans',
-    author_email='pieter.roggemans@gmail.com',
-    description='Package to do spatial operations on geo files.',
+    author="Pieter Roggemans",
+    author_email="pieter.roggemans@gmail.com",
+    description="Package to do spatial operations on geo files.",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/geofileops/geofileops',
+    long_description_content_type="text/markdown",
+    url="https://github.com/geofileops/geofileops",
     include_package_data=True,
     packages=setuptools.find_packages(),
-    install_requires=['cloudpickle', 'gdal', 'geopandas>=0.10', 'pygeos', 'pyproj', 'psutil'],
+    install_requires=["cloudpickle", "fiona", "gdal", "geopandas>=0.10", "pygeos", "pyproj", "psutil", "shapely"],
     extras_require = {
-        'full': ['simplification']
+        "full": ["simplification"]
     },
     classifiers=[
-        'Programming Language :: Python :: 3',
-        'Operating System :: OS Independent',
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
     ],
-    python_requires='>=3.8',
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
Some packages are imported/used directly in geofileops, but they are only installed because another package used in geofileops has a dependency on them. 
So, if this other package would remove the dependency, geofileops breaks.

So, all packages that are used directly should be explicitly mentioned in the dependencies. 

Related to #101