### PR TITLE
Always use simplify that preserves topology

### DIFF
--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -337,7 +337,7 @@ def simplify(
 
     # Prepare sql template for this operation 
     sql_template = f'''
-            SELECT ST_Simplify({{geometrycolumn}}, {tolerance}) AS geom
+            SELECT ST_SimplifyPreserveTopology({{geometrycolumn}}, {tolerance}) AS geom
                   {{columns_to_select_str}} 
               FROM "{{input_layer}}" layer
              WHERE 1=1 

--- a/geofileops/util/geoseries_util.py
+++ b/geofileops/util/geoseries_util.py
@@ -185,7 +185,7 @@ def simplify_ext(
         lookahead: int = 8) -> gpd.GeoSeries:
     # If ramer-douglas-peucker, use standard geopandas algorithm
     if algorithm is geometry_util.SimplifyAlgorithm.RAMER_DOUGLAS_PEUCKER:
-        return geoseries.simplify(tolerance=tolerance)
+        return geoseries.simplify(tolerance=tolerance, preserve_topology=True)
     else:
         # For other algorithms, use vector_util.simplify_ext()
         return gpd.GeoSeries(


### PR DESCRIPTION
Now in the sql functions simplify without preserve is used (the default there), in paths that use geopandas with preservetopology (the default).

Make it consistent that preserve topology is always applied/tried.