### PR TITLE
Add simplification as install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setuptools.setup(
         "pygeos",
         "pyproj",
         "shapely",
-        "topojson"
+        "simplification",
+        "topojson",
     ],
     extras_require={"full": ["simplification", "topojson"]},
     classifiers=[


### PR DESCRIPTION
It is optional, but seems just easier to install it by default to avoid hassle.