### PR TITLE
Activate simplification in ci of python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           - ci/envs/38-latest-conda-forge.yaml
           - ci/envs/39-latest-conda-forge.yaml
           - ci/envs/310-latest-conda-forge.yaml
-          - ci/envs/311-latest-conda-forge_no-simpification.yaml
+          - ci/envs/311-latest-conda-forge.yaml
         include:
           - env: ci/envs/39-latest-conda-forge.yaml
             os: macos-latest

--- a/ci/envs/311-latest-conda-forge.yaml
+++ b/ci/envs/311-latest-conda-forge.yaml
@@ -19,5 +19,5 @@ dependencies:
   # testing
   - pytest
   - pytest-cov
-  #- pip:
-  #  - simplification
+  - pip:
+    - simplification


### PR DESCRIPTION
simplification lib is now available for python 3.11