### PR TITLE
Make writing to gpkg more robust in locking situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.6.3 (???)
+
+### Bugs fixed
+
+- Make writing to gpkg more robust in locking situations (#179)
+
 ## 0.6.2 (2022-11-14)
 
 ### Bugs fixed

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -1398,7 +1398,7 @@ def move(src: Union[str, "os.PathLike[Any]"], dst: Union[str, "os.PathLike[Any]"
     geofiletype = GeofileType(src)
 
     # Move the main file
-    shutil.move(str(src), dst, copy_function=_io_util.copyfile)
+    shutil.move(str(src), dst)
 
     # For some file types, extra files need to be moved
     # If dest is a dir, just use move. Otherwise concat dest filepaths
@@ -1407,13 +1407,13 @@ def move(src: Union[str, "os.PathLike[Any]"], dst: Union[str, "os.PathLike[Any]"
             for suffix in geofiletype.suffixes_extrafiles:
                 srcfile = src.parent / f"{src.stem}{suffix}"
                 if srcfile.exists():
-                    shutil.move(str(srcfile), dst, copy_function=_io_util.copyfile)
+                    shutil.move(str(srcfile), dst)
         else:
             for suffix in geofiletype.suffixes_extrafiles:
                 srcfile = src.parent / f"{src.stem}{suffix}"
                 dstfile = dst.parent / f"{dst.stem}{suffix}"
                 if srcfile.exists():
-                    shutil.move(str(srcfile), dstfile, copy_function=_io_util.copyfile)
+                    shutil.move(str(srcfile), dstfile)
 
 
 def remove(path: Union[str, "os.PathLike[Any]"], missing_ok: bool = False):

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -356,7 +356,9 @@ def get_only_layer(path: Union[str, "os.PathLike[Any]"]) -> str:
     datasource = None
     try:
         datasource_layer = None
-        datasource = gdal.OpenEx(str(path))
+        datasource = gdal.OpenEx(
+            str(path), nOpenFlags=gdal.OF_VECTOR | gdal.OF_READONLY | gdal.OF_SHARED
+        )
         nb_layers = datasource.GetLayerCount()
         if nb_layers == 1:
             datasource_layer = datasource.GetLayerByIndex(0)
@@ -1095,7 +1097,7 @@ def to_file(
     # If the dataframe is empty, return
     if len(gdf) <= 0:
         return
-    
+
     # If no layer name specified, determine one
     if layer is None:
         if append and path.exists():
@@ -1132,19 +1134,6 @@ def to_file(
                 mode = "w"
         else:
             mode = "w"
-
-        """
-        # Fiona silently doesn't append data to an existing layer if the columns don't
-        # match. To be able to raise an exception when this happens, get info of dest
-        # layer now to compare results afterwards.
-        dst_info_orig = None
-        if mode == "a":
-            # If dst_layer exists in the dst file
-            if layer is not None and layer in listlayers(path):
-                # If source data actually contains data
-                if len(gdf) > 0:
-                    dst_info_orig = get_layerinfo(path, layer)
-        """
 
         geofiletype = GeofileType(path)
         if geofiletype == GeofileType.ESRIShapefile:
@@ -1251,6 +1240,13 @@ def to_file(
                         remove(gdftemp_path)
                         if gdftemp_lockpath is not None:
                             gdftemp_lockpath.unlink()
+                except Exception as ex:
+                    # If sqlite output file locked, also retry
+                    if geofiletype.is_spatialite_based and str(ex) not in [
+                        "database is locked",
+                        "attempt to write a readonly database",
+                    ]:
+                        raise ex
                 finally:
                     ready = True
                     lockfile.unlink()

--- a/geofileops/util/_io_util.py
+++ b/geofileops/util/_io_util.py
@@ -124,14 +124,7 @@ def copyfile(src: Union[str, "os.PathLike[Any]"], dst: Union[str, "os.PathLike[A
 
     else:
         # If the destination is a dir, make it a full file path
-        dst_p = Path(dst)
-        if dst_p.is_dir():
-            src_p = Path(src)
-            dst_p = dst_p / src_p.name
-
-        buffer_size = 1024 * 1024 * 5
-        with open(src, "rb") as fsrc, open(dst_p, "wb") as fdest:
-            shutil.copyfileobj(fsrc, fdest, buffer_size)
+        shutil.copy2(src=src, dst=dst)
 
 
 '''

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -290,6 +290,7 @@ def vector_translate(
 
     # Now we can really get to work
     input_ds = None
+    result_ds = None
     try:
         # In some cases gdal only raises the last exception instead of the stack in
         # VectorTranslate, so you lose necessary details!
@@ -312,7 +313,7 @@ def vector_translate(
             raise Exception("BOOM")
         else:
             if result_ds.GetLayerCount() == 0:
-                del result_ds
+                result_ds = None
                 if output_path.exists():
                     gfo.remove(output_path)
     except Exception as ex:
@@ -322,6 +323,8 @@ def vector_translate(
     finally:
         if input_ds is not None:
             del input_ds
+        if result_ds is not None:
+            del result_ds
 
     return True
 

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -383,6 +383,15 @@ def test_move(tmp_path, suffix):
     if suffix == ".shp":
         assert dst.with_suffix(".shx").exists()
 
+    # Add column to make sure the dst file isn't locked
+    if suffix == ".gpkg":
+        gfo.add_column(
+            path=dst,
+            name="PERIMETER",
+            type=gfo.DataType.REAL,
+            expression="ST_perimeter(geom)",
+        )
+
 
 def test_update_column(tmp_path):
     test_path = test_helper.get_testfile("polygon-parcel", dst_dir=tmp_path)

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -144,6 +144,15 @@ def test_export_by_location(tmp_path, suffix):
     output_gdf = gfo.read_file(output_path)
     assert output_gdf["geometry"][0] is not None
 
+    # Add column to make sure the output file isn't locked
+    if suffix == ".gpkg":
+        gfo.add_column(
+            output_path,
+            name="PERIMETER",
+            type=gfo.DataType.REAL,
+            expression="ST_perimeter(geom)",
+        )
+
 
 @pytest.mark.parametrize("testfile", ["polygon-parcel"])
 @pytest.mark.parametrize("suffix", DEFAULT_SUFFIXES)

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -144,15 +144,6 @@ def test_export_by_location(tmp_path, suffix):
     output_gdf = gfo.read_file(output_path)
     assert output_gdf["geometry"][0] is not None
 
-    # Add column to make sure the output file isn't locked
-    if suffix == ".gpkg":
-        gfo.add_column(
-            output_path,
-            name="PERIMETER",
-            type=gfo.DataType.REAL,
-            expression="ST_perimeter(geom)",
-        )
-
 
 @pytest.mark.parametrize("testfile", ["polygon-parcel"])
 @pytest.mark.parametrize("suffix", DEFAULT_SUFFIXES)


### PR DESCRIPTION
- On a k8 cluster, for a volume mounted via cifs there seem issues that gpkg files remain locked. When add_column is ran after eg. the export_by_location operation this error is raised: database is locked. The lock is gone when the script ends, so might be an issue that locks are "delayed" in getting cleared? Not able to reproduce in a dev environment.
   - solution tried: remove custom implementation for copy-file in gfo.move() as it apparently isn't faster anymore. 
- On windows, when appending to a gpkg file, "attempt to write a readonly database" occurs sometimes (on a network location). Mark that there is already a locking mechanism using lock files in place in to_file().
   - solution: use retry mechanism also if geopackage is locked 