### PR TITLE
Support geopandas 12 with shapely 2.0 + pygeos

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,9 @@ jobs:
           - ci/envs/310-latest-conda-forge.yaml
           - ci/envs/311-latest-conda-forge.yaml
         include:
+          - env: ci/envs/39-latest-conda-forge-shapely1.yaml
+            os: ubuntu-latest
+            dev: false
           - env: ci/envs/39-latest-conda-forge.yaml
             os: macos-latest
             dev: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.7.0 (???)
+
+### Improvements
+
+- Support geopandas 12 with shapely 2.0 + pygeos (#191)
+
 ## 0.6.3 (2022-12-12)
 
 ### Improvements

--- a/ci/envs/39-latest-conda-forge-shapely1.yaml
+++ b/ci/envs/39-latest-conda-forge-shapely1.yaml
@@ -1,0 +1,23 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  - pip
+  # required
+  - cloudpickle
+  - fiona
+  - gdal
+  - geopandas
+  - numpy
+  - pandas
+  - psutil
+  - pygeos
+  - pyproj
+  - shapely<2
+  - topojson
+  # testing
+  - pytest
+  - pytest-cov
+  - pip:
+    - simplification

--- a/geofileops/__init__.py
+++ b/geofileops/__init__.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import os
+os.environ['USE_PYGEOS'] = '1'
 
 from geofileops.fileops import *
 from geofileops.geoops import *

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -1767,4 +1767,4 @@ def _add_orderby_column(path: Path, layer: str, name: str):
     # Now we can actually add the column.
     gfo.add_column(path=path, name=name, type=gfo.DataType.TEXT, expression=expression)
     sqlite_stmt = f'CREATE INDEX {name}_idx ON "{layer}"({name})'
-    _ogr_util.vector_info(path=path, sql_stmt=sqlite_stmt, readonly=False)
+    gfo.execute_sql(path=path, sql_stmt=sqlite_stmt)

--- a/geofileops/util/geoseries_util.py
+++ b/geofileops/util/geoseries_util.py
@@ -52,8 +52,8 @@ def get_geometrytypes(
 
     Args:
         geoseries (gpd.GeoSeries): input geoseries.
-        ignore_empty_geometries (bool, optional): True to ignore empty
-            geometries as they can be of a different type. Defaults to True.
+        ignore_empty_geometries (bool, optional): True to ignore empty geometries.
+            Defaults to True.
 
     Returns:
         List[GeometryType]: [description]
@@ -139,7 +139,7 @@ def _harmonize_to_multitype(
     geometries_arr = geoseries.array.data.copy()  # type: ignore
 
     # Set empty geometries to None
-    empty_idxs = pygeos.get_type_id(geometries_arr) == 7
+    empty_idxs = pygeos.is_empty(geometries_arr)
     if empty_idxs.sum():
         geometries_arr[empty_idxs] = None
 

--- a/geofileops/util/geoseries_util.py
+++ b/geofileops/util/geoseries_util.py
@@ -50,14 +50,10 @@ def get_geometrytypes(
     """
     Determine the geometry types in the GeoDataFrame.
 
-    In a GeoDataFrame, empty geometries are always treated as
-    geometrycollections. These are by default ignored.
-
     Args:
         geoseries (gpd.GeoSeries): input geoseries.
         ignore_empty_geometries (bool, optional): True to ignore empty
-            geometries, as they are always stored as GeometryCollections by
-            GeoPandas. Defaults to True.
+            geometries as they can be of a different type. Defaults to True.
 
     Returns:
         List[GeometryType]: [description]
@@ -88,8 +84,7 @@ def harmonize_geometrytypes(
     Eg. if Polygons and MultiPolygons are present in the geoseries, all
     geometries are converted to MultiPolygons.
 
-    Empty geometries are changed to None, because Empty geometries are always
-    treated as GeometryCollections by GeoPandas.
+    Empty geometries are changed to None.
 
     If they cannot be harmonized, the original series is returned...
 

--- a/geofileopsdev.yml
+++ b/geofileopsdev.yml
@@ -3,20 +3,19 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - cryptography<=36
   - pip
   # required
   - cloudpickle
   - fiona
   - gdal
   - geopandas>=0.11,<=0.12
+  - libspatialite>=5.0
   - numpy
   - pandas
   - psutil
   - pygeos
   - pyproj
   - shapely
-  - libspatialite>=5.0
   - topojson
   # testing
   - pytest

--- a/geofileopsdev.yml
+++ b/geofileopsdev.yml
@@ -8,7 +8,7 @@ dependencies:
   - cloudpickle
   - fiona
   - gdal
-  - geopandas>=0.11,<=0.12
+  - geopandas>=0.11
   - libspatialite>=5.0
   - numpy
   - pandas

--- a/tests/test_geofileops_singlelayer_gpd.py
+++ b/tests/test_geofileops_singlelayer_gpd.py
@@ -6,6 +6,7 @@ Tests for operations using GeoPandas.
 import json
 import math
 from pathlib import Path
+import platform
 import sys
 
 import geopandas as gpd
@@ -390,6 +391,10 @@ def test_dissolve_polygons_groupby_None(tmp_path):
     )
 
 
+@pytest.mark.skipif(
+    platform.system() == "Darwin",
+    reason="test gives a segmentation fault on MacOS since 20522-12-20?",
+)
 @pytest.mark.parametrize("suffix", DEFAULT_SUFFIXES)
 def test_dissolve_polygons_specialcases(tmp_path, suffix):
     # Prepare test data

--- a/tests/test_geofileops_singlelayer_gpd.py
+++ b/tests/test_geofileops_singlelayer_gpd.py
@@ -391,10 +391,6 @@ def test_dissolve_polygons_groupby_None(tmp_path):
     )
 
 
-@pytest.mark.skipif(
-    platform.system() == "Darwin",
-    reason="test gives a segmentation fault on MacOS since 20522-12-20?",
-)
 @pytest.mark.parametrize("suffix", DEFAULT_SUFFIXES)
 def test_dissolve_polygons_specialcases(tmp_path, suffix):
     # Prepare test data


### PR DESCRIPTION
- Some code changes to support the changed behaviour as explained here: https://shapely.readthedocs.io/en/latest/migration.html#consistent-creation-of-empty-geometries
- Should be backwards compatible, so shapely < 2 should still work as well.
- pygeos is still used for spatial operations because once full change to shapely 2.0 is activated it isn't possibly anymore (according to the documentation) to use pygeos? -> to be further investigated.
- _ogr_util.vector_info was used in the dissolve operation to create an attribute index, but this now gives a segmentation fault on MacOS/Darwin. Using gfo.execute_sql instead solved the problem.