### PR TITLE
Using read_file, string columns with all None values ends up as float64 column using fiona >= 1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Support geopandas 12 with shapely 2.0 + pygeos (#191, #193)
 - Support improvements in gdal 3.6.2 (#195)
 
+### Bugs fixed
+
+- Using read_file with fiona >= 1.9, string columns with all None values end up as float64 column (#199)
+
 ## 0.6.3 (2022-12-12)
 
 ### Improvements

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -19,6 +19,7 @@ import warnings
 import fiona
 import geopandas as gpd
 from geopandas.io import file as gpd_io_file
+import numpy as np
 from osgeo import gdal
 import pandas as pd
 import pyproj
@@ -996,9 +997,25 @@ def _read_file_base(
         columns_upper = [column.upper() for column in columns]
         columns_upper.append("GEOMETRY")
         columns_to_keep = [
-            col for col in result_gdf.columns if (col.upper() in columns_upper)
+            col for col in result_gdf.columns if (str(col).upper() in columns_upper)
         ]
         result_gdf = result_gdf[columns_to_keep]
+
+    # Starting from fiona 1.9, string columns with all None values are read as being
+    # float columns. Convert them to object type.
+    float_cols = list(result_gdf.select_dtypes(["float64"]).columns)
+    if len(float_cols) > 0:
+        # Check for all float columns found if they should be object columns instead
+        with fiona.open(path, layer=layer) as collection:
+            assert collection.schema is not None
+            properties = collection.schema["properties"]
+            for col in float_cols:
+                if col in properties and properties[col].startswith("str"):
+                    result_gdf[col] = (
+                        result_gdf[col]  # type: ignore
+                        .astype(object)
+                        .replace(np.nan, None)
+                    )
 
     # assert to evade pyLance warning
     assert isinstance(result_gdf, pd.DataFrame) or isinstance(

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "cloudpickle",
-        "fiona<1.9",
+        "fiona",
         "gdal",
         "geopandas>=0.10",
         "numpy",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "cloudpickle",
-        "fiona",
+        "fiona<1.9",
         "gdal",
         "geopandas>=0.10",
         "numpy",

--- a/tests/test_geofileops_singlelayer_gpd.py
+++ b/tests/test_geofileops_singlelayer_gpd.py
@@ -363,14 +363,19 @@ def test_dissolve_polygons(
 
 
 def test_dissolve_polygons_groupby_None(tmp_path):
+    """
+    Test dissolve polygons with a column with None values. There was once an issue
+    that the type of the column with None Values always ended up as a REAL column after
+    the dissolve/group by instead of the original type.
+    """
+
     # Prepare test data
     input_path = test_helper.get_testfile("polygon-parcel", dst_dir=tmp_path)
     gfo.add_column(input_path, name="none_values", type=gfo.DataType.TEXT)
     input_layerinfo = gfo.get_layerinfo(input_path)
     batchsize = math.ceil(input_layerinfo.featurecount / 2)
 
-    # Test dissolve polygons with different options for groupby and explodecollections
-    # --------------------------------------------------------------------------------
+    # Run test
     output_path = tmp_path / "output.gpkg"
     gfo.dissolve(
         input_path=input_path,


### PR DESCRIPTION
When reading empty data from a column in a gpkg, Fiona doesn't offer the distinction anymore between None (string) and nan (real/numeric) columns starting from version 1.9, resulting in GeoPandas interpreting them as float64 columns instead of object columns.

This fix converts these columns to "object" type after reading.

Closes #199