### PR TITLE
Optimize performance of single layer sql operations when nb_parallel = 1

### DIFF
--- a/benchmark/benchmark_geofileops.py
+++ b/benchmark/benchmark_geofileops.py
@@ -1,7 +1,7 @@
 import benchmarker
 
 if __name__ == "__main__":
-    # benchmarker.run_benchmarks(["benchmarks_geofileops"])
+    benchmarker.run_benchmarks(["benchmarks_geofileops"])
 
     # Only run specific benchmark function(s)
-    benchmarker.run_benchmarks(["benchmarks_geofileops"], ["buffer"])
+    # benchmarker.run_benchmarks(["benchmarks_geofileops"], ["clip"])

--- a/benchmark/benchmark_geofileops.py
+++ b/benchmark/benchmark_geofileops.py
@@ -1,7 +1,7 @@
 import benchmarker
 
 if __name__ == "__main__":
-    benchmarker.run_benchmarks(["benchmarks_geofileops"])
+    # benchmarker.run_benchmarks(["benchmarks_geofileops"])
 
     # Only run specific benchmark function(s)
-    # benchmarker.run_benchmarks(["benchmarks_geofileops"], ["clip"])
+    benchmarker.run_benchmarks(["benchmarks_geofileops"], ["buffer"])

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -540,13 +540,17 @@ def _single_layer_vector_operation(
                 tmp_partial_output_path = batches[batch_id]["tmp_partial_output_path"]
 
                 if tmp_partial_output_path.exists():
-                    gfo.append_to(
-                        src=tmp_partial_output_path,
-                        dst=tmp_output_path,
-                        dst_layer=output_layer,
-                        create_spatial_index=False,
-                    )
-                    gfo.remove(tmp_partial_output_path)
+                    # If there is only one batch, just rename
+                    if len(processing_params.batches) == 1:
+                        gfo.move(tmp_partial_output_path, tmp_output_path)
+                    else:
+                        gfo.append_to(
+                            src=tmp_partial_output_path,
+                            dst=tmp_output_path,
+                            dst_layer=output_layer,
+                            create_spatial_index=False,
+                        )
+                        gfo.remove(tmp_partial_output_path)
                 else:
                     logger.debug(f"Result file {tmp_partial_output_path} was empty")
 


### PR DESCRIPTION
Where there is only one batch, only one temp partial file, so can be renamed instead of appended.

related to #19 