### PR TITLE
Fix spatial index not being created in two-layer operation with nb_parallel=1

### DIFF
--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -503,9 +503,9 @@ def create_spatial_index(
 
     # If index already exists, remove index or return
     if has_spatial_index(path, layer):
-        if force_rebuild is True:
+        if force_rebuild:
             remove_spatial_index(path, layer)
-        elif exist_ok is True:
+        elif exist_ok:
             return
         else:
             raise Exception(

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -502,7 +502,7 @@ def create_spatial_index(
         layer = get_only_layer(path)
 
     # If index already exists, remove index or return
-    if has_spatial_index(path, layer) is True:
+    if has_spatial_index(path, layer):
         if force_rebuild is True:
             remove_spatial_index(path, layer)
         elif exist_ok is True:
@@ -518,12 +518,26 @@ def create_spatial_index(
         geofiletype = GeofileType(path)
         if geofiletype.is_spatialite_based:
             # The config options need to be set before opening the file!
-            geometrycolumn = get_layerinfo(path, layer).geometrycolumn
+            layerinfo = get_layerinfo(path, layer)
             with _ogr_util.set_config_options({"OGR_SQLITE_CACHE": cache_size_mb}):
                 datasource = gdal.OpenEx(str(path), nOpenFlags=gdal.OF_UPDATE)
+                geometrycolumn = layerinfo.geometrycolumn
                 sql = f"SELECT CreateSpatialIndex('{layer}', '{geometrycolumn}')"
                 result = datasource.ExecuteSQL(sql, dialect="SQLITE")
                 datasource.ReleaseResultSet(result)
+
+                # Verify if the index was created
+                sql = f"SELECT HasSpatialIndex('{layerinfo.name}', '{geometrycolumn}')"
+                result = datasource.ExecuteSQL(sql, dialect="SQLITE")
+                has_spatial_idx = result.GetNextFeature().GetField(0) == 1
+                datasource.ReleaseResultSet(result)
+
+                # Apparently failed, if gpkg, try again with other function
+                if not has_spatial_idx and geofiletype == GeofileType.GPKG:
+                    sql = f"SELECT gpkgAddSpatialIndex('{layer}', '{geometrycolumn}')"
+                    result = datasource.ExecuteSQL(sql, dialect="SQLITE")
+                    datasource.ReleaseResultSet(result)
+
         else:
             datasource = gdal.OpenEx(str(path), nOpenFlags=gdal.OF_UPDATE)
             result = datasource.ExecuteSQL(f'CREATE SPATIAL INDEX ON "{layer}"')
@@ -533,6 +547,9 @@ def create_spatial_index(
     finally:
         if datasource is not None:
             del datasource
+
+    if not has_spatial_index(path, layer):
+        raise RuntimeError(f"create_spatial_index failed on {path}, layer: {layer}")
 
 
 def has_spatial_index(

--- a/geofileops/util/_geoops_ogr.py
+++ b/geofileops/util/_geoops_ogr.py
@@ -35,6 +35,7 @@ def clip_by_geometry(
         geom = wkt.loads(clip_geometry)
         spatial_filter = tuple(geom.bounds)
 
+    options = {"LAYER_CREATION.SPATIAL_INDEX": True}
     _run_ogr(
         operation="clip_by_geometry",
         input_path=input_path,
@@ -45,6 +46,7 @@ def clip_by_geometry(
         output_layer=output_layer,
         columns=columns,
         explodecollections=explodecollections,
+        options=options,
         force=force,
     )
 
@@ -59,6 +61,7 @@ def export_by_bounds(
     explodecollections: bool = False,
     force: bool = False,
 ):
+    options = {"LAYER_CREATION.SPATIAL_INDEX": True}
     _run_ogr(
         operation="export_by_bounds",
         input_path=input_path,
@@ -68,6 +71,7 @@ def export_by_bounds(
         output_layer=output_layer,
         columns=columns,
         explodecollections=explodecollections,
+        options=options,
         force=force,
     )
 

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -801,10 +801,10 @@ def erase(
         output_layer=output_layer,
         explodecollections=explodecollections,
         force_output_geometrytype=force_output_geometrytype,
-        output_with_spatial_index=output_with_spatial_index,
         nb_parallel=nb_parallel,
         batchsize=batchsize,
         force=force,
+        output_with_spatial_index=output_with_spatial_index,
     )
 
 
@@ -1773,6 +1773,8 @@ def _two_layer_vector_operation(
             smaller nb_parallel, will reduce the memory usage.
             Defaults to -1: (try to) determine optimal size automatically.
         force (bool, optional): [description]. Defaults to False.
+        output_with_spatial_index (bool, optional): True to create output file with
+            spatial index. Defaults to True.
 
     Raises:
         Exception: [description]
@@ -1992,21 +1994,21 @@ def _two_layer_vector_operation(
                         tmp_partial_output_path.exists()
                         and tmp_partial_output_path.stat().st_size > 0
                     ):
-                        # If only one batch and output format same as tmp, rename file
-                        if (
-                            len(processing_params.batches) == 1
-                            and tmp_partial_output_path.suffix.lower()
-                            == tmp_output_path.suffix.lower()
-                        ):
-                            gfo.move(tmp_partial_output_path, tmp_output_path)
-                        else:
-                            fileops._append_to_nolock(
-                                src=tmp_partial_output_path,
-                                dst=tmp_output_path,
-                                explodecollections=explodecollections,
-                                force_output_geometrytype=force_output_geometrytype,
-                                create_spatial_index=False,
-                            )
+                        # If only one batch, immediately create index.
+                        # Remark: copying the file using ogr is still necessary, even
+                        # if only 1 batch, because apparently gpkg created with
+                        # create_table_as_sql isn't 100% OK: impossible to create a
+                        # valid spatial index on it.
+                        create_spatial_index = False
+                        if len(processing_params.batches) == 1:
+                            create_spatial_index = True
+                        fileops._append_to_nolock(
+                            src=tmp_partial_output_path,
+                            dst=tmp_output_path,
+                            explodecollections=explodecollections,
+                            force_output_geometrytype=force_output_geometrytype,
+                            create_spatial_index=create_spatial_index,
+                        )
                     else:
                         logger.debug(f"Result file {tmp_partial_output_path} was empty")
 
@@ -2030,8 +2032,10 @@ def _two_layer_vector_operation(
         # Round up and clean up
         # Now create spatial index and move to output location
         if tmp_output_path.exists():
-            if output_with_spatial_index is True:
-                gfo.create_spatial_index(path=tmp_output_path, layer=output_layer)
+            if output_with_spatial_index:
+                gfo.create_spatial_index(
+                    path=tmp_output_path, layer=output_layer, exist_ok=True
+                )
             if tmp_output_path != output_path:
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 gfo.move(tmp_output_path, output_path)
@@ -2040,8 +2044,8 @@ def _two_layer_vector_operation(
 
         logger.info(f"{operation_name} ready, took {datetime.now()-start_time}!")
     except Exception:
-        gfo.remove(output_path)
-        gfo.remove(tmp_output_path)
+        gfo.remove(output_path, missing_ok=True)
+        gfo.remove(tmp_output_path, missing_ok=True)
         raise
     finally:
         shutil.rmtree(tempdir)

--- a/tests/test_geofileops_singlelayer.py
+++ b/tests/test_geofileops_singlelayer.py
@@ -106,6 +106,7 @@ def test_buffer(tmp_path, suffix, epsg, fileops_module, testfile, empty_input):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
+    assert fileops.has_spatial_index(output_path)
     output_layerinfo = fileops.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == len(input_layerinfo.columns)
 
@@ -169,6 +170,7 @@ def test_buffer_columns_fid(tmp_path, suffix, fileops_module, testfile):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
+    assert fileops.has_spatial_index(output_path)
     output_layerinfo = fileops.get_layerinfo(output_path)
     output_gdf = fileops.read_file(output_path)
     assert output_gdf["geometry"][0] is not None
@@ -195,6 +197,7 @@ def test_buffer_force(tmp_path):
 
     # Test buffer to existing output path
     assert output_path.exists()
+    assert fileops.has_spatial_index(output_path)
     mtime_orig = output_path.stat().st_mtime
     geoops.buffer(
         input_path=input_path,
@@ -245,6 +248,7 @@ def test_buffer_negative(tmp_path, suffix, fileops_module, testfile):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
+    assert fileops.has_spatial_index(output_path)
     output_layerinfo = fileops.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == len(input_layerinfo.columns)
 
@@ -302,6 +306,7 @@ def test_buffer_negative_explode(tmp_path, fileops_module):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
+    assert fileops.has_spatial_index(output_path)
     layerinfo_output = fileops.get_layerinfo(output_path)
     assert len(layerinfo_output.columns) == len(input_layerinfo.columns)
 
@@ -352,6 +357,7 @@ def test_convexhull(tmp_path, fileops_module, suffix, empty_input):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
+    assert fileops.has_spatial_index(output_path)
     layerinfo_output = fileops.get_layerinfo(output_path)
     assert "OIDN" in layerinfo_output.columns
     assert "uidn" in layerinfo_output.columns
@@ -406,6 +412,7 @@ def test_simplify(tmp_path, suffix, epsg, fileops_module, testfile, empty_input)
 
     # Now check if the tmp file is correctly created
     assert output_path.exists()
+    assert fileops.has_spatial_index(output_path)
     output_layerinfo = fileops.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == len(input_layerinfo.columns)
 

--- a/tests/test_geofileops_singlelayer_gpd.py
+++ b/tests/test_geofileops_singlelayer_gpd.py
@@ -71,6 +71,7 @@ def test_apply(tmp_path, suffix, only_geom_input, force_output_geometrytype):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
+    assert gfo.has_spatial_index(output_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert input_layerinfo.featurecount == (output_layerinfo.featurecount + 1)
     assert len(output_layerinfo.columns) == len(input_layerinfo.columns)
@@ -177,6 +178,7 @@ def test_dissolve_linestrings(tmp_path, suffix, epsg):
 
     # Check if the result file is correctly created
     assert output_path.exists()
+    assert gfo.has_spatial_index(output_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert output_layerinfo.featurecount == 83
     assert output_layerinfo.geometrytype in [
@@ -369,6 +371,7 @@ def test_dissolve_polygons(
 
     # Now check if the tmp file is correctly created
     assert output_path.exists()
+    assert gfo.has_spatial_index(output_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert output_layerinfo.featurecount == expected_featurecount
     if groupby is True:
@@ -848,6 +851,7 @@ def test_simplify_vw(tmp_path, suffix, epsg, testfile):
 
     # Check if the file is correctly created
     assert output_path.exists()
+    assert gfo.has_spatial_index(output_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert input_layerinfo.featurecount == output_layerinfo.featurecount
     assert len(input_layerinfo.columns) == len(output_layerinfo.columns)
@@ -895,6 +899,7 @@ def test_simplify_lang(tmp_path, suffix, epsg, testfile):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
+    assert gfo.has_spatial_index(output_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert input_layerinfo.featurecount == output_layerinfo.featurecount
     assert len(input_layerinfo.columns) == len(output_layerinfo.columns)

--- a/tests/test_geofileops_singlelayer_ogr.py
+++ b/tests/test_geofileops_singlelayer_ogr.py
@@ -46,7 +46,7 @@ def test_clip_by_geometry(tmp_path, suffix):
 
 
 @pytest.mark.parametrize("suffix", DEFAULT_SUFFIXES)
-def test_export_by_geometry(tmp_path, suffix):
+def test_export_by_bounds(tmp_path, suffix):
     # Prepare test data
     input_path = test_helper.get_testfile("polygon-parcel", suffix=suffix)
 

--- a/tests/test_geofileops_singlelayer_ogr.py
+++ b/tests/test_geofileops_singlelayer_ogr.py
@@ -33,6 +33,7 @@ def test_clip_by_geometry(tmp_path, suffix):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
+    assert gfo.has_spatial_index(output_path)
     layerinfo_orig = gfo.get_layerinfo(input_path)
     layerinfo_output = gfo.get_layerinfo(output_path)
     assert layerinfo_output.featurecount == 22
@@ -56,6 +57,7 @@ def test_export_by_geometry(tmp_path, suffix):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
+    assert gfo.has_spatial_index(output_path)
     layerinfo_orig = gfo.get_layerinfo(input_path)
     layerinfo_output = gfo.get_layerinfo(output_path)
     assert layerinfo_output.featurecount == 25
@@ -92,6 +94,7 @@ def test_warp(tmp_path):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
+    assert gfo.has_spatial_index(output_path)
     layerinfo_orig = gfo.get_layerinfo(input_path)
     layerinfo_output = gfo.get_layerinfo(output_path)
     assert layerinfo_output.featurecount == layerinfo_orig.featurecount


### PR DESCRIPTION
Problem was introduced in #213 

Additional change: create spatial index for shp in all spatial operations: behaviour was different for each operation