### PR TITLE
Fix missing fid in gpkg created with create table as sql

### DIFF
--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 
 # Enable exceptions for GDAL
 gdal.UseExceptions()
+gdal.ogr.UseExceptions()
 
 # Disable this warning in fiona
 warnings.filterwarnings(
@@ -525,19 +526,6 @@ def create_spatial_index(
                 sql = f"SELECT CreateSpatialIndex('{layer}', '{geometrycolumn}')"
                 result = datasource.ExecuteSQL(sql, dialect="SQLITE")
                 datasource.ReleaseResultSet(result)
-
-                # Verify if the index was created
-                sql = f"SELECT HasSpatialIndex('{layerinfo.name}', '{geometrycolumn}')"
-                result = datasource.ExecuteSQL(sql, dialect="SQLITE")
-                has_spatial_idx = result.GetNextFeature().GetField(0) == 1
-                datasource.ReleaseResultSet(result)
-
-                # Apparently failed, if gpkg, try again with other function
-                if not has_spatial_idx and geofiletype == GeofileType.GPKG:
-                    sql = f"SELECT gpkgAddSpatialIndex('{layer}', '{geometrycolumn}')"
-                    result = datasource.ExecuteSQL(sql, dialect="SQLITE")
-                    datasource.ReleaseResultSet(result)
-
         else:
             datasource = gdal.OpenEx(str(path), nOpenFlags=gdal.OF_UPDATE)
             result = datasource.ExecuteSQL(f'CREATE SPATIAL INDEX ON "{layer}"')

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -2033,6 +2033,7 @@ def _two_layer_vector_operation(
                             and len(processing_params.batches) == 1
                         ):
                             create_spatial_index = True
+
                         fileops._append_to_nolock(
                             src=tmp_partial_output_path,
                             dst=tmp_output_path,

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -2040,6 +2040,7 @@ def _two_layer_vector_operation(
                             explodecollections=explodecollections,
                             force_output_geometrytype=force_output_geometrytype,
                             create_spatial_index=create_spatial_index,
+                            preserve_fid=False,
                         )
                     else:
                         logger.debug(f"Result file {tmp_partial_output_path} was empty")

--- a/geofileops/util/_sqlite_util.py
+++ b/geofileops/util/_sqlite_util.py
@@ -174,8 +174,11 @@ def create_table_as_sql(
                 conn.execute(sql)
 
             # Set nb KB of cache
-            conn.execute("PRAGMA cache_size=-128000;")
-            conn.execute("PRAGMA temp_store=MEMORY;")
+            sql = "PRAGMA cache_size=-128000;"
+            conn.execute(sql)
+            # Set temp storage to MEMORY
+            sql = "PRAGMA temp_store=2;"
+            conn.execute(sql)
 
             # If attach to input1
             input1_databasename = "input1"
@@ -221,10 +224,14 @@ def create_table_as_sql(
             # Determine columns/datatypes to create the table
             # Create temp table to get the column names + general data types
             # + fetch one row to use it to determine geometrytype.
-            sql = (
-                f"CREATE TEMPORARY TABLE tmp AS \n"
-                f"    SELECT * FROM (\n{sql_stmt}\n)\nLIMIT 1;"
-            )
+            sql = f"""
+                CREATE TEMPORARY TABLE tmp AS
+                  SELECT *
+                    FROM (
+                      {sql_stmt}
+                    )
+                  LIMIT 1;
+            """
             conn.execute(sql)
             sql = "PRAGMA TABLE_INFO(tmp)"
             cur = conn.execute(sql)
@@ -323,10 +330,12 @@ def create_table_as_sql(
                 f'"{columnname}" {column_types[columnname]}\n'
                 for columnname in column_types
             ]
-            sql = (
-                f'CREATE TABLE {output_databasename}."{output_layer}" '
-                f'({", ".join(columns_for_create)})'
-            )
+            sql = f"""
+                CREATE TABLE {output_databasename}."{output_layer}" (
+                    fid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    {", ".join(columns_for_create)}
+                )
+            """
             conn.execute(sql)
 
             # Add metadata


### PR DESCRIPTION
The gdal SQLITE function `CreateSpatialIndex()` didn't work on files created by `_sqlite_util.create_table_as_sql`. Problem was apparently that the fid column wasn't present:
  - added the fid column
  - added `preserve_fid=False` to the append() call that appends these files, because the default gdal behaviour apparently lead to it trying to insert duplicate fid's.
  - removed the obsololete (and not really working) code trying to recover the problem in `fileops.create_spatial_index()`