### PR TITLE
Fix error in add_layerstyle if qml contains single quote

### DIFF
--- a/tests/data/polygonstyle.qml
+++ b/tests/data/polygonstyle.qml
@@ -1,4 +1,4 @@
-<!DOCTYPE qgis PUBLIC "http://mrcc.com/qgis.dtd" "SYSTEM">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
 <qgis simplifyDrawingHints="1" readOnly="0" labelsEnabled="0" simplifyLocal="1" maxScale="0" minScale="100000000" simplifyMaxScale="1" simplifyDrawingTol="1" version="3.22.0-Białowieża" hasScaleBasedVisibilityFlag="0" symbologyReferenceScale="-1" styleCategories="AllStyleCategories" simplifyAlgorithm="0">
 	<flags>
 		<Identifiable>1</Identifiable>

--- a/tests/data/polygonstyle.sld
+++ b/tests/data/polygonstyle.sld
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" version="1.1.0" xmlns:se="http://www.opengis.net/se">
 	<NamedLayer>
 		<se:Name>trees_18_419_SE-testroi-2022</se:Name>


### PR DESCRIPTION
Uses bind variables now to avoid these kind of issues...

reference #263 