### PR TITLE
Rename convert to copy_layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
   changed to `True` in a future version. This is also explained in a futurewarning (#262)
 - removed the long-deprecated functions `get_driver`, `get_driver_for_ext`,
   `to_multi_type` and `to_generaltypeid`  (#276)
-- rename and deprecate `convert` to `copy_layer` and `copy` to `copy_geofile` (#310)
+- rename and deprecate `convert` to `copy_layer` (#310)
 - removed the long-deprecated `vector_util`, `geofileops.geofile` and
   `geofileops.geofileops` namespaces (#276)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   changed to `True` in a future version. This is also explained in a futurewarning (#262)
 - removed the long-deprecated functions `get_driver`, `get_driver_for_ext`,
   `to_multi_type` and `to_generaltypeid`  (#276)
+- rename and deprecate `convert` to `copy_layer` and `copy` to `copy_geofile` (#310)
 - removed the long-deprecated `vector_util`, `geofileops.geofile` and
   `geofileops.geofileops` namespaces (#276)
 

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -1127,7 +1127,7 @@ def _read_file_base_fiona(
         tmp_fid_path = Path(tempfile.mkdtemp()) / f"{path.stem}.gpkg"
         try:
             if GeofileType(path) == GeofileType.GPKG:
-                copy_geofile(path, tmp_fid_path)
+                copy(path, tmp_fid_path)
                 add_column(tmp_fid_path, "__TMP_GEOFILEOPS_FID", "INTEGER", "fid")
             else:
                 copy_layer(path, tmp_fid_path)
@@ -1813,16 +1813,6 @@ def cmp(
 
 
 def copy(src: Union[str, "os.PathLike[Any]"], dst: Union[str, "os.PathLike[Any]"]):
-    """
-    DEPRECATED: please use copy_geofile.
-    """
-    warnings.warn("geofileops.copy is deprecated: use copy_geofile.", FutureWarning)
-    return copy_geofile(src=src, dst=dst)
-
-
-def copy_geofile(
-    src: Union[str, "os.PathLike[Any]"], dst: Union[str, "os.PathLike[Any]"]
-):
     """
     Copies the geofile from src to dst. Is the source file is a geofile containing
     of multiple files (eg. .shp) all files are copied.

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -1127,10 +1127,10 @@ def _read_file_base_fiona(
         tmp_fid_path = Path(tempfile.mkdtemp()) / f"{path.stem}.gpkg"
         try:
             if GeofileType(path) == GeofileType.GPKG:
-                copy(path, tmp_fid_path)
+                copy_geofile(path, tmp_fid_path)
                 add_column(tmp_fid_path, "__TMP_GEOFILEOPS_FID", "INTEGER", "fid")
             else:
-                convert(path, tmp_fid_path)
+                copy_layer(path, tmp_fid_path)
                 # fid in shapefile is 0 based, so fid-1
                 add_column(tmp_fid_path, "__TMP_GEOFILEOPS_FID", "INTEGER", "fid-1")
 
@@ -1814,6 +1814,16 @@ def cmp(
 
 def copy(src: Union[str, "os.PathLike[Any]"], dst: Union[str, "os.PathLike[Any]"]):
     """
+    DEPRECATED: please use copy_geofile.
+    """
+    warnings.warn("geofileops.copy is deprecated: use copy_geofile.", FutureWarning)
+    return copy_geofile(src=src, dst=dst)
+
+
+def copy_geofile(
+    src: Union[str, "os.PathLike[Any]"], dst: Union[str, "os.PathLike[Any]"]
+):
+    """
     Copies the geofile from src to dst. Is the source file is a geofile containing
     of multiple files (eg. .shp) all files are copied.
 
@@ -2164,6 +2174,46 @@ def convert(
     force: bool = False,
 ):
     """
+    DEPRECATED: please use copy_layer.
+    """
+    warnings.warn("convert is deprecated: use copy_layer.", FutureWarning)
+    return copy_layer(
+        src=src,
+        dst=dst,
+        src_layer=src_layer,
+        dst_layer=dst_layer,
+        src_crs=src_crs,
+        dst_crs=dst_crs,
+        where=where,
+        reproject=reproject,
+        explodecollections=explodecollections,
+        force_output_geometrytype=force_output_geometrytype,
+        create_spatial_index=create_spatial_index,
+        preserve_fid=preserve_fid,
+        options=options,
+        append=append,
+        force=force,
+    )
+
+
+def copy_layer(
+    src: Union[str, "os.PathLike[Any]"],
+    dst: Union[str, "os.PathLike[Any]"],
+    src_layer: Optional[str] = None,
+    dst_layer: Optional[str] = None,
+    src_crs: Union[str, int, None] = None,
+    dst_crs: Union[str, int, None] = None,
+    where: Optional[str] = None,
+    reproject: bool = False,
+    explodecollections: bool = False,
+    force_output_geometrytype: Union[GeometryType, str, None] = None,
+    create_spatial_index: Optional[bool] = True,
+    preserve_fid: Optional[bool] = None,
+    options: dict = {},
+    append: bool = False,
+    force: bool = False,
+):
+    """
     Read a layer from a source file and write it to a new destination file.
 
     Typically used to convert from one fileformat to another or to reproject.
@@ -2236,7 +2286,7 @@ def convert(
     # If source file doesn't exist, raise error
     if not src.exists():
         raise ValueError(f"src file doesn't exist: {src}")
-    # If dest file exists already, remove it
+    # If dest file exists already and no append
     if not append and dst.exists():
         if force is True:
             remove(dst)

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -1492,7 +1492,7 @@ def join_nearest(
         tempdir = _io_util.create_tempdir("geofileops/join_nearest")
         input1_tmp_path = tempdir / "both_input_layers.sqlite"
         input1_tmp_layer = "input1_layer"
-        gfo.convert(
+        gfo.copy_layer(
             src=input1_path,
             src_layer=input1_layer,
             dst=input1_tmp_path,
@@ -1820,7 +1820,7 @@ def symmetric_difference(
         if erase1_output_path.suffix != output_path.suffix:
             # Output file should be in diffent format, so convert
             tmp_output_path = tempdir / output_path.name
-            gfo.convert(src=erase1_output_path, dst=tmp_output_path)
+            gfo.copy_layer(src=erase1_output_path, dst=tmp_output_path)
         else:
             # Create spatial index
             gfo.create_spatial_index(path=tmp_output_path, layer=output_layer)
@@ -1920,7 +1920,7 @@ def union(
         if split_output_path.suffix != output_path.suffix:
             # Output file should be in different format, so convert
             tmp_output_path = tempdir / output_path.name
-            gfo.convert(src=split_output_path, dst=tmp_output_path)
+            gfo.copy_layer(src=split_output_path, dst=tmp_output_path)
         else:
             # Create spatial index
             gfo.create_spatial_index(path=tmp_output_path, layer=output_layer)
@@ -2505,7 +2505,7 @@ def _prepare_processing_params(
         else:
             # If not ok, copy the input layer to gpkg
             returnvalue.input1_path = tempdir / f"{input1_path.stem}.gpkg"
-            gfo.convert(
+            gfo.copy_layer(
                 src=input1_path,
                 src_layer=input1_layer,
                 dst=returnvalue.input1_path,
@@ -2525,7 +2525,7 @@ def _prepare_processing_params(
             else:
                 # If not spatialite compatible, copy the input layer to gpkg
                 returnvalue.input2_path = tempdir / f"{input2_path.stem}.gpkg"
-                gfo.convert(
+                gfo.copy_layer(
                     src=input2_path,
                     src_layer=input2_layer,
                     dst=returnvalue.input2_path,

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -142,7 +142,7 @@ def test_append_different_columns(tmp_path, suffix):
         "polygon-parcel", dst_dir=tmp_path, suffix=suffix
     )
     dst_path = tmp_path / f"dst{suffix}"
-    gfo.copy_geofile(src_path, dst_path)
+    gfo.copy(src_path, dst_path)
     gfo.add_column(src_path, name="extra_column", type=gfo.DataType.INTEGER)
     gfo.append_to(src_path, dst_path)
 
@@ -161,7 +161,7 @@ def test_cmp(tmp_path, suffix):
 
     # Copy test file to tmpdir
     dst = tmp_path / f"polygons_parcels_output{suffix}"
-    gfo.copy_geofile(src, dst)
+    gfo.copy(src, dst)
 
     # Now compare source and dst files
     assert gfo.cmp(src, dst) is True
@@ -315,7 +315,7 @@ def test_copy(tmp_path, suffix):
 
     # Copy to dest file
     dst = tmp_path / f"{src.stem}-output{suffix}"
-    gfo.copy_geofile(src, dst)
+    gfo.copy(src, dst)
     assert src.exists()
     assert dst.exists()
     if suffix == ".shp":
@@ -324,7 +324,7 @@ def test_copy(tmp_path, suffix):
     # Copy to dest dir
     dst_dir = tmp_path / "dest_dir"
     dst_dir.mkdir(parents=True, exist_ok=True)
-    gfo.copy_geofile(src, dst_dir)
+    gfo.copy(src, dst_dir)
     dst = dst_dir / src.name
     assert src.exists()
     assert dst.exists()

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -142,7 +142,7 @@ def test_append_different_columns(tmp_path, suffix):
         "polygon-parcel", dst_dir=tmp_path, suffix=suffix
     )
     dst_path = tmp_path / f"dst{suffix}"
-    gfo.copy(src_path, dst_path)
+    gfo.copy_geofile(src_path, dst_path)
     gfo.add_column(src_path, name="extra_column", type=gfo.DataType.INTEGER)
     gfo.append_to(src_path, dst_path)
 
@@ -161,7 +161,7 @@ def test_cmp(tmp_path, suffix):
 
     # Copy test file to tmpdir
     dst = tmp_path / f"polygons_parcels_output{suffix}"
-    gfo.copy(src, dst)
+    gfo.copy_geofile(src, dst)
 
     # Now compare source and dst files
     assert gfo.cmp(src, dst) is True
@@ -174,7 +174,7 @@ def test_convert(tmp_path, suffix):
 
     # Convert
     dst = tmp_path / f"{src.stem}-output{suffix}"
-    gfo.convert(src, dst)
+    gfo.copy_layer(src, dst)
 
     # Now compare source and dst file
     src_layerinfo = gfo.get_layerinfo(src)
@@ -190,7 +190,7 @@ def test_convert_emptyfile(tmp_path, suffix):
         "polygon-parcel", suffix=suffix, dst_dir=tmp_path, empty=True
     )
     dst = tmp_path / f"{src.stem}-output{suffix}"
-    gfo.convert(src, dst)
+    gfo.copy_layer(src, dst)
 
     # Now compare source and dst file
     assert dst.exists()
@@ -218,7 +218,7 @@ def test_convert_force_output_geometrytype(tmp_path, testfile, force_geometrytyp
     # Convert testfile and force to force_geometrytype
     src = test_helper.get_testfile(testfile)
     dst = tmp_path / f"{src.stem}_to_{force_geometrytype}.gpkg"
-    gfo.convert(src, dst, force_output_geometrytype=force_geometrytype)
+    gfo.copy_layer(src, dst, force_output_geometrytype=force_geometrytype)
     assert gfo.get_layerinfo(dst).geometrytype == force_geometrytype
 
 
@@ -227,7 +227,7 @@ def test_convert_invalid_params(tmp_path):
     src = tmp_path / "nonexisting_file.gpkg"
     dst = tmp_path / "output.gpkg"
     with pytest.raises(ValueError, match="src file doesn't exist: "):
-        gfo.convert(src, dst)
+        gfo.copy_layer(src, dst)
 
 
 @pytest.mark.parametrize(
@@ -252,7 +252,7 @@ def test_convert_preserve_fid(
     # Convert with preserve_fid=None (default)
     # ----------------------------------------
     dst = tmp_path / f"{src.stem}-output_preserve_fid-{preserve_fid}{dst_suffix}"
-    gfo.convert(src, dst, preserve_fid=preserve_fid)
+    gfo.copy_layer(src, dst, preserve_fid=preserve_fid)
 
     # Now compare source and dst file
     src_gdf = gfo.read_file(src, fid_as_index=True)
@@ -272,7 +272,7 @@ def test_convert_reproject(tmp_path, suffix, src_crs):
 
     # Convert with reproject
     dst = tmp_path / f"{src.stem}-output_reproj4326{suffix}"
-    gfo.convert(src, dst, src_crs=src_crs, dst_crs=4326, reproject=True)
+    gfo.copy_layer(src, dst, src_crs=src_crs, dst_crs=4326, reproject=True)
 
     # Now compare source and dst file
     src_layerinfo = gfo.get_layerinfo(src)
@@ -300,7 +300,7 @@ def test_convert_where(tmp_path, suffix):
 
     # Convert with where
     dst = tmp_path / f"{src.stem}-output_where{suffix}"
-    gfo.convert(src, dst, where="ST_Area({geometrycolumn}) > 500")
+    gfo.copy_layer(src, dst, where="ST_Area({geometrycolumn}) > 500")
 
     # Now compare source and dst file
     src_layerinfo = gfo.get_layerinfo(src)
@@ -315,7 +315,7 @@ def test_copy(tmp_path, suffix):
 
     # Copy to dest file
     dst = tmp_path / f"{src.stem}-output{suffix}"
-    gfo.copy(src, dst)
+    gfo.copy_geofile(src, dst)
     assert src.exists()
     assert dst.exists()
     if suffix == ".shp":
@@ -324,7 +324,7 @@ def test_copy(tmp_path, suffix):
     # Copy to dest dir
     dst_dir = tmp_path / "dest_dir"
     dst_dir.mkdir(parents=True, exist_ok=True)
-    gfo.copy(src, dst_dir)
+    gfo.copy_geofile(src, dst_dir)
     dst = dst_dir / src.name
     assert src.exists()
     assert dst.exists()
@@ -417,7 +417,7 @@ def test_get_layer_geometrytypes_geometry(tmp_path):
     # Prepare test data + test
     src = test_helper.get_testfile("polygon-parcel", suffix=".gpkg")
     test_path = tmp_path / f"{src.stem}_geometry{src.suffix}"
-    gfo.convert(src, test_path, force_output_geometrytype="GEOMETRY")
+    gfo.copy_layer(src, test_path, force_output_geometrytype="GEOMETRY")
     assert gfo.get_layerinfo(test_path).geometrytypename == "GEOMETRY"
     geometrytypes = gfo.get_layer_geometrytypes(src)
     assert geometrytypes == ["POLYGON", "MULTIPOLYGON"]

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -109,7 +109,7 @@ def prepare_test_file(
             assert input_layerinfo.crs is not None
             if input_layerinfo.crs.to_epsg() == crs_epsg:
                 if input_path.suffix == suffix:
-                    gfo.copy_geofile(input_path, input_prepared_path)
+                    gfo.copy(input_path, input_prepared_path)
                 else:
                     gfo.copy_layer(input_path, input_prepared_path)
             else:
@@ -126,7 +126,7 @@ def prepare_test_file(
     # Now copy the prepared file to the output dir
     output_path = output_dir / input_prepared_path.name
     if str(input_prepared_path) != str(output_path):
-        gfo.copy_geofile(input_prepared_path, output_path)
+        gfo.copy(input_prepared_path, output_path)
     return output_path
 
 

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -109,9 +109,9 @@ def prepare_test_file(
             assert input_layerinfo.crs is not None
             if input_layerinfo.crs.to_epsg() == crs_epsg:
                 if input_path.suffix == suffix:
-                    gfo.copy(input_path, input_prepared_path)
+                    gfo.copy_geofile(input_path, input_prepared_path)
                 else:
-                    gfo.convert(input_path, input_prepared_path)
+                    gfo.copy_layer(input_path, input_prepared_path)
             else:
                 test_gdf = gfo.read_file(input_path)
                 test_gdf = test_gdf.to_crs(crs_epsg)
@@ -121,12 +121,12 @@ def prepare_test_file(
         # No crs specified, but different suffix asked, so convert file
         input_prepared_path = tmp_cache_dir / f"{input_path.stem}{suffix}"
         if input_prepared_path.exists() is False:
-            gfo.convert(input_path, input_prepared_path)
+            gfo.copy_layer(input_path, input_prepared_path)
 
     # Now copy the prepared file to the output dir
     output_path = output_dir / input_prepared_path.name
     if str(input_prepared_path) != str(output_path):
-        gfo.copy(input_prepared_path, output_path)
+        gfo.copy_geofile(input_prepared_path, output_path)
     return output_path
 
 
@@ -160,7 +160,7 @@ def get_testfile(
 
     # Convert all layers found
     for layer in layers:
-        gfo.convert(
+        gfo.copy_layer(
             testfile_path,
             prepared_path,
             src_layer=layer,

--- a/tests/test_layerstyles.py
+++ b/tests/test_layerstyles.py
@@ -49,7 +49,7 @@ def test_add_get_remove_layer_styles(tmp_path):
 
     # Backup the styled file to be a able to check it manually in QGIS
     styled_path = tmp_path / f"{test_path.stem}_styled{test_path.suffix}"
-    gfo.copy(src=test_path, dst=styled_path)
+    gfo.copy_geofile(src=test_path, dst=styled_path)
 
     # Remove the style again
     gfo.remove_layerstyle(test_path, id=1)

--- a/tests/test_layerstyles.py
+++ b/tests/test_layerstyles.py
@@ -49,7 +49,7 @@ def test_add_get_remove_layer_styles(tmp_path):
 
     # Backup the styled file to be a able to check it manually in QGIS
     styled_path = tmp_path / f"{test_path.stem}_styled{test_path.suffix}"
-    gfo.copy_geofile(src=test_path, dst=styled_path)
+    gfo.copy(src=test_path, dst=styled_path)
 
     # Remove the style again
     gfo.remove_layerstyle(test_path, id=1)


### PR DESCRIPTION
Deprecate the old name that stays available for backwards compatibility.

closes #310 