### PR TITLE
Support creating geofile without geometry column using gfo.select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   (#262)
 - Add `where` parameter to many two layer spatial operations (#312)
 - Add `where` parameter to `gfo.convert` and `gfo.append_to` (#311)
+- Support creating geofile without geometry column using `gfo.select` (#322)
 - Improve performance of makevalid and isvalid (#258)
 - Improve performance of spatial operations when only one batch is used (#271)
 - Add checks that `output_path` must not be equal to the/an `input_path` for geo

--- a/geofileops/util/geofiletypes.csv
+++ b/geofileops/util/geofiletypes.csv
@@ -1,6 +1,6 @@
-geofiletype,   ogrdriver,        suffixes,       is_fid_zerobased, is_spatialite_based, suffixes_extrafiles
-ESRIShapefile, "ESRI Shapefile", "['.shp']",     True,             False,               "['.shp', '.dbf', '.shx', '.prj', '.qix', '.sbn', '.sbx']"
-GeoJSON,       GeoJSON,          "['.geojson']", True,             False,               
-GPKG,          GPKG,             "['.gpkg']",    False,            True,                "['gpkg-journal']"
-SQLite,        SQLite,           "['.sqlite']",  False,            True,                
-FlatGeobuf,    FlatGeobuf,       "['.fgb']",     True,             False,               
+geofiletype,   ogrdriver,        suffixes,              is_fid_zerobased, is_spatialite_based, suffixes_extrafiles
+ESRIShapefile, "ESRI Shapefile", "['.shp', '.dbf']",    True,             False,               "['.shp', '.dbf', '.shx', '.prj', '.qix', '.sbn', '.sbx']"
+GeoJSON,       GeoJSON,          "['.geojson']",        True,             False,               
+GPKG,          GPKG,             "['.gpkg']",           False,            True,                "['gpkg-journal']"
+SQLite,        SQLite,           "['.sqlite']",         False,            True,                
+FlatGeobuf,    FlatGeobuf,       "['.fgb']",            True,             False,               


### PR DESCRIPTION
Now, if you use `gfo.select` on an input file without geometry column or if you don't select a geometry column in you sql_stmt this leads to an error.

This PR adds support for both cases.

Remark: a shapefile without geometry column is in fact only a .dbf file: both .shp and .shx files are missing.