### PR TITLE
Improve performance/memory usage of `split`, especially for files with very large input geometries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@
 - Add `where` parameter to `gfo.convert` and `gfo.append_to` (#311)
 - Support creating geofile without geometry column using `gfo.select` (#322)
 - Improve performance of `makevalid` and `isvalid` (#258)
-- Improve performance of spatial operations when only one batch is used (#271)
-- Improvements to `erase`: files with very large input geometries 100x faster + 10x less
+- Improvements to `erase`: for files with very large input geometries, 100x faster + 10x less
   memory usage (#329, #330)
+- Improvemets to `split`: for files with very large input geometries, 2x faster + 10x less
+  memory usage (#331)
+- Improve performance of spatial operations when only one batch is used (#271)
 - Add checks that `output_path` must not be equal to the/an `input_path` for geo
   operations (#246)
 - Follow geopandas behaviour of using shapely2 and/or pygeos instead of forcing pygeos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@
 - Add `where` parameter to `gfo.convert` and `gfo.append_to` (#311)
 - Support creating geofile without geometry column using `gfo.select` (#322)
 - Improve performance of `makevalid` and `isvalid` (#258)
-- Improvements to `erase`: for files with very large input geometries, 100x faster + 10x less
-  memory usage (#329, #330)
-- Improvemets to `split`: for files with very large input geometries, 2x faster + 10x less
-  memory usage (#331)
+- Improvements to `erase`: for files with very large input geometries, 100x faster +
+  10x less memory usage. (#329, #330)
+- Several operations are based on `erase` and/or `split` and get benefits from the
+  improvements above:
+  - `symmetric difference`: is fully based on `erase`, so gets the same improvement.
+  - `union`: is based and `erase` and `split`.
+- Improvements to `split`: for files with very large input geometries, 2x faster + 10x less
+  memory usage. Because `split` is also used in ``  (#331)
 - Improve performance of spatial operations when only one batch is used (#271)
 - Add checks that `output_path` must not be equal to the/an `input_path` for geo
   operations (#246)

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -936,12 +936,11 @@ def erase(
         force_output_geometrytype = input_layer_info.geometrytype.to_multitype
 
     # Prepare sql template for this operation
-    # - WHERE geom IS NOT NULL to evade rows with a NULL geom, they give issues in
+    # - WHERE geom IS NOT NULL to avoid rows with a NULL geom, they give issues in
     #   later operations
-    # - use "LIMIT -1 OFFSET 0" to avoid the subquery flattening. Flattening
+    # - use "LIMIT -1 OFFSET 0" to avoid the subquery flattening. Flattening e.g.
     #   "geom IS NOT NULL" leads to ST_Difference_Collection calculated double!
     # - ST_Intersects and ST_Touches slow down a lot when the data contains huge geoms
-    # - Not relevant anymore, but ST_difference(geometry , NULL) gives NULL as result
     # - Calculate difference in correlated subquery in SELECT clause
     # - Using a WITH with a GROUP BY on layer1.rowid was a few % faster, but this
     #   processed the entire batch in memory so used > 10 * more memory. E.g. for one
@@ -953,6 +952,7 @@ def erase(
     #   Tried to return EMPTY GEOMETRY from ST_Difference_Collection, but it didn't
     #   work to use spatialite's ST_IsEmpty(geom) = 0 to filter on this for an unclear
     #   reason.
+    # - Not relevant anymore, but ST_difference(geometry , NULL) gives NULL as result
     input1_layer_rtree = "rtree_{input1_layer}_{input1_geometrycolumn}"
     input2_layer_rtree = "rtree_{input2_layer}_{input2_geometrycolumn}"
 
@@ -1681,76 +1681,25 @@ def split(
     force_output_geometrytype = primitivetype_to_extract.to_multitype
 
     # Prepare sql template for this operation
-    # Remarks:
-    #   - ST_difference(geometry , NULL) gives NULL as result! -> hence the CASE
-    #   - the group by layer1.rowid should be directly in the subquery. If it is
-    #     applied on an (other) with it is slow.
-    #   - a left join is a lot faster and memory efficient than a NOT IN or NOT EXISTS.
+    # - WHERE geom IS NOT NULL to avoid rows with a NULL geom, they give issues in
+    #   later operations
+    # - use "LIMIT -1 OFFSET 0" to avoid the subquery flattening. Flattening e.g.
+    #   "geom IS NOT NULL" leads to ST_Difference_Collection calculated double!
+    # - ST_Intersects and ST_Touches slow down a lot when the data contains huge geoms
+    # - Calculate difference in correlated subquery in SELECT clause
+    # - Using a WITH with a GROUP BY on layer1.rowid was a few % faster, but this
+    #   processed the entire batch in memory so used > 10 * more memory. E.g. for one
+    #   test file 4-7 GB per process versus 70-700 MB). For another: crash.
+    # - Check if the result of ST_Difference_Collection is empty (NULL) using IFNULL,
+    #   and if this ois the case set to 'DIFF_EMPTY'. This way we can make the
+    #   distinction whether the subquery is finding a row (no match with spatial index)
+    #   or if the difference results in an empty/NULL geometry.
+    #   Tried to return EMPTY GEOMETRY from ST_Difference_Collection, but it didn't
+    #   work to use spatialite's ST_IsEmpty(geom) = 0 to filter on this for an unclear
+    #   reason.
+    # - Not relevant anymore, but ST_difference(geometry , NULL) gives NULL as result
     input1_layer_rtree = "rtree_{input1_layer}_{input1_geometrycolumn}"
     input2_layer_rtree = "rtree_{input2_layer}_{input2_geometrycolumn}"
-    sql_template = f"""
-        SELECT * FROM
-          ( WITH layer2_unioned AS (
-              SELECT layer1.rowid AS layer1_rowid
-                    ,ST_union(layer2.{{input2_geometrycolumn}}) AS geom
-                FROM {{input1_databasename}}."{{input1_layer}}" layer1
-                JOIN {{input1_databasename}}."{input1_layer_rtree}" layer1tree
-                  ON layer1.fid = layer1tree.id
-                JOIN {{input2_databasename}}."{{input2_layer}}" layer2
-                JOIN {{input2_databasename}}."{input2_layer_rtree}" layer2tree
-                  ON layer2.fid = layer2tree.id
-               WHERE 1=1
-                 {{batch_filter}}
-                 AND layer1tree.minx <= layer2tree.maxx
-                 AND layer1tree.maxx >= layer2tree.minx
-                 AND layer1tree.miny <= layer2tree.maxy
-                 AND layer1tree.maxy >= layer2tree.miny
-                 AND ST_Intersects(layer1.{{input1_geometrycolumn}},
-                                   layer2.{{input2_geometrycolumn}}) = 1
-                 AND ST_Touches(layer1.{{input1_geometrycolumn}},
-                                layer2.{{input2_geometrycolumn}}) = 0
-               GROUP BY layer1.rowid
-            )
-            SELECT ST_CollectionExtract(
-                        ST_intersection(layer1.{{input1_geometrycolumn}},
-                                        layer2.{{input2_geometrycolumn}}),
-                        {primitivetype_to_extract.value}) as geom
-                  {{layer1_columns_prefix_alias_str}}
-                  {{layer2_columns_prefix_alias_str}}
-              FROM {{input1_databasename}}."{{input1_layer}}" layer1
-              JOIN {{input1_databasename}}."{input1_layer_rtree}" layer1tree
-                ON layer1.fid = layer1tree.id
-              JOIN {{input2_databasename}}."{{input2_layer}}" layer2
-              JOIN {{input2_databasename}}."{input2_layer_rtree}" layer2tree
-                ON layer2.fid = layer2tree.id
-             WHERE 1=1
-               {{batch_filter}}
-               AND layer1tree.minx <= layer2tree.maxx
-               AND layer1tree.maxx >= layer2tree.minx
-               AND layer1tree.miny <= layer2tree.maxy
-               AND layer1tree.maxy >= layer2tree.miny
-               AND ST_Intersects(layer1.{{input1_geometrycolumn}},
-                                 layer2.{{input2_geometrycolumn}}) = 1
-               AND ST_Touches(layer1.{{input1_geometrycolumn}},
-                              layer2.{{input2_geometrycolumn}}) = 0
-            UNION ALL
-            SELECT CASE WHEN layer2_unioned.geom IS NULL
-                        THEN layer1.{{input1_geometrycolumn}}
-                        ELSE ST_CollectionExtract(
-                                ST_difference(layer1.{{input1_geometrycolumn}},
-                                              layer2_unioned.geom),
-                                {primitivetype_to_extract.value})
-                   END as geom
-                  {{layer1_columns_prefix_alias_str}}
-                  {{layer2_columns_prefix_alias_null_str}}
-              FROM {{input1_databasename}}."{{input1_layer}}" layer1
-              LEFT JOIN layer2_unioned ON layer1.rowid = layer2_unioned.layer1_rowid
-             WHERE 1=1
-               {{batch_filter}}
-           )
-         WHERE geom IS NOT NULL
-           AND ST_NPoints(geom) > 0
-    """
 
     sql_template = f"""
         SELECT * FROM (


### PR DESCRIPTION
Improvements:
- The WITH statement with GROUP BY is removed, which reduces the the memory usage for large files by > 10x
- The difference part of the query is replaced by the optimized functions from the `erase` operation

TODO: the intersection part can still be optimized for complex geometries, the following issue has been registered for this: #332