### PR TITLE
Fix trigger error with drop_column for some gpkg files

### DIFF
--- a/geofileops/util/_sqlite_util.py
+++ b/geofileops/util/_sqlite_util.py
@@ -73,6 +73,21 @@ def create_new_spatialdb(path: Path, crs_epsg: Optional[int] = None):
                 if crs_epsg is not None and crs_epsg not in [0, -1, 4326]:
                     sql = f"SELECT gpkgInsertEpsgSRID({crs_epsg})"
                     conn.execute(sql)
+
+                # If they are present, remove triggers that were removed from the gpkg
+                # spec because of issues but apparently weren't removed in spatialite.
+                # https://github.com/opengeospatial/geopackage/pull/240
+                sql = "DROP TRIGGER gpkg_metadata_reference_row_id_value_insert;"
+                try:
+                    conn.execute(sql)
+                except Exception:
+                    pass
+                sql = "DROP TRIGGER gpkg_metadata_reference_row_id_value_update;"
+                try:
+                    conn.execute(sql)
+                except Exception:
+                    pass
+
             elif output_suffix_lower == ".sqlite":
                 sql = "SELECT InitSpatialMetaData(1);"
                 conn.execute(sql)

--- a/tests/test_sqlite_util.py
+++ b/tests/test_sqlite_util.py
@@ -56,6 +56,12 @@ def test_create_table_as_sql(tmp_path, create_spatial_index):
     output_info = gfo.get_layerinfo(output_path)
     assert output_info.featurecount == 7
 
+    # The gpkg created by spatialite by default include some triggers that have errors
+    # and were removed from the gpkg spec but not removed in spatialite.
+    # These operations give errors if the triggers are still there.
+    gfo.drop_column(output_path, column_name="naam")
+    gfo.rename_layer(output_path, layer=output_path.stem, new_layer="test_layername")
+
 
 @pytest.mark.parametrize(
     "kwargs, expected_error",


### PR DESCRIPTION
Some triggeres were removed from the gpkg spec because of issues but apparently weren't removed in spatialite function "SELECT gpkgCreateBaseTables();".

Triggers involved
https://github.com/opengeospatial/geopackage/pull/240

Fix: drop them after using `gpkgCreateBaseTables`.