### PR TITLE
Fix placement of LIMIT OFFSET clauses for gridsize and where subselects

### DIFF
--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -2265,8 +2265,8 @@ def _two_layer_vector_operation(
                 SELECT {gridsize_op} AS geom
                         {columns_to_select}
                   FROM ( {sql_template}
+                         LIMIT -1 OFFSET 0
                   ) sub_gridsize
-                 LIMIT -1 OFFSET 0
             """
 
         # Prepare/apply where parameter
@@ -2278,9 +2278,9 @@ def _two_layer_vector_operation(
             sql_template = f"""
                 SELECT * FROM
                     ( {sql_template}
+                      LIMIT -1 OFFSET 0
                     )
                  WHERE {where}
-                 LIMIT -1 OFFSET 0
             """
             # Where has been applied already so set to None.
             where = None


### PR DESCRIPTION
The "LIMIT -1 OFFSET 0 " meant to avoid the subquery flattening was placed after the outer query instead of in the subquery... so didn't do a lot...