### PR TITLE
Improve performance for clip and intersection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 - Add support for lang+ algorithm in `gfo.simplify` (#334)
 - Support creating geofile without geometry column using `gfo.select` (#322)
 - Improve performance of `makevalid` and `isvalid` (#258)
-- Improve performance of `intersection` for large input geometries: 2x faster (#340)
+- Improve performance of `intersection`, 30% faster for typical data, up to 4x faster
+  for large input geometries (#340, #)
+- Improve performance of `clip`: 3x faster for typical data (#)
 - Support on-the-fly subdividing of complex geometries to speed up processing in
   `erase`, `split`, `symmetric difference` and `union` (#329, #330, #331, #357).
   The new parameter `subdivide_coords` can be used to control the feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 - Support creating geofile without geometry column using `gfo.select` (#322)
 - Improve performance of `makevalid` and `isvalid` (#258)
 - Improve performance of `intersection`, 30% faster for typical data, up to 4x faster
-  for large input geometries (#340, #)
-- Improve performance of `clip`: 3x faster for typical data (#)
+  for large input geometries (#340, #358)
+- Improve performance of `clip`: 3x faster for typical data (#358)
 - Support on-the-fly subdividing of complex geometries to speed up processing in
   `erase`, `split`, `symmetric difference` and `union` (#329, #330, #331, #357).
   The new parameter `subdivide_coords` can be used to control the feature.

--- a/benchmark/benchmark_geofileops.py
+++ b/benchmark/benchmark_geofileops.py
@@ -4,9 +4,10 @@ from benchmark import benchmarker
 def main():
     # Run the benchmark function(s)
     functions_to_run = [
-        # "intersection",
+        # "clip",
+        "intersection",
         # "intersection_gridsize",
-        "symmetric_difference_complexpoly_agri",
+        # "symmetric_difference_complexpoly_agri",
     ]
     # Run all bechmark functions
     # functions_to_run = None


### PR DESCRIPTION
Add some `LIMIT -1 OFFSET 0` in sql statements of `clip`and ìntersection` to improve execution plan and avoid executing expesive geo operations twice.