### PR TITLE
Preserve fid values when possible in single layer operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,7 @@
 - Add function `get_layer_geometrytypes` to get a list of all geometry types that
   are actually in a layer (#230)
 - Add `fid_as_index` parameter to `read_file` (#215)
-- Add `force_output_geometrytype` parameter to `apply` (#233)
-- Add `fid_as_index` parameter to `read_file` (#215)
+- Preserve `fid` values in single layer operations when possible (#)
 - Add `force_output_geometrytype` parameter to `apply` (#233)
 - Optimize performance of operations when only one batch is used (#19)
 - Optimize number batches for single layer sql operations (#214)

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -1218,6 +1218,7 @@ def _read_file_base_fiona(
     # Set the index to the backed-up fid
     if fid_as_index:
         result_gdf = result_gdf.set_index("__TMP_GEOFILEOPS_FID")
+        result_gdf.index.name = "fid"
 
     # Reorder columns + change casing so they are the same as columns parameter
     if columns_prepared is not None and len(columns_prepared) > 0:

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -57,6 +57,9 @@ def apply(
             ``func=lambda row: pygeoops.remove_inner_rings(``
                     ``row.geometry, min_area_to_keep=1)``
 
+    If ``explodecollections`` is False and the output file is a GeoPackage, the fid
+    will be preserved. In other cases this will typically not be the case.
+
     Args:
         input_path (PathLike): the input file
         output_path (PathLike): the file to write the result to
@@ -154,6 +157,9 @@ def buffer(
     Applies a buffer operation on geometry column of the input file.
 
     The result is written to the output file specified.
+
+    If ``explodecollections`` is False and the output file is a GeoPackage, the fid
+    will be preserved. In other cases this will typically not be the case.
 
     Args:
         input_path (PathLike): the input file
@@ -416,6 +422,9 @@ def convexhull(
 
     The result is written to the output file specified.
 
+    If ``explodecollections`` is False and the output file is a GeoPackage, the fid
+    will be preserved. In other cases this will typically not be the case.
+
     Args:
         input_path (PathLike): the input file
         output_path (PathLike): the file to write the result to
@@ -492,6 +501,9 @@ def delete_duplicate_geometries(
 ):
     """
     Copy all rows to the output file, except for duplicate geometries.
+
+    If ``explodecollections`` is False and the output file is a GeoPackage, the fid
+    will be preserved. In other cases this will typically not be the case.
 
     Args:
         input_path (PathLike): the input file
@@ -796,6 +808,9 @@ def isvalid(
 
     The results are written to the output file.
 
+    If ``explodecollections`` is False and the output file is a GeoPackage, the fid
+    will be preserved. In other cases this will typically not be the case.
+
     Args:
         input_path (PathLike): The input file.
         output_path (PathLike, optional): The output file path. If not
@@ -877,6 +892,9 @@ def makevalid(
     Alternative names:
         - QGIS: fix geometries
         - shapely: make_valid
+
+    If ``explodecollections`` is False and the output file is a GeoPackage, the fid
+    will be preserved. In other cases this will typically not be the case.
 
     Args:
         input_path (PathLike): The input file.
@@ -1189,6 +1207,9 @@ def simplify(
     Applies a simplify operation on geometry column of the input file.
 
     The result is written to the output file specified.
+
+    If ``explodecollections`` is False and the output file is a GeoPackage, the fid
+    will be preserved. In other cases this will typically not be the case.
 
     Args:
         input_path (PathLike): the input file

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -373,6 +373,9 @@ def clip_by_geometry(
     """
     Clip all geometries in the imput file by the geometry provided.
 
+    If ``explodecollections`` is False and the output file is a GeoPackage, the fid
+    will be preserved. In other cases this will typically not be the case.
+
     Args:
         input_path (PathLike): the input file
         output_path (PathLike): the file to write the result to
@@ -760,6 +763,9 @@ def export_by_bounds(
 ):
     """
     Export the rows that intersect with the bounds specified.
+
+    If ``explodecollections`` is False and the output file is a GeoPackage, the fid
+    will be preserved. In other cases this will typically not be the case.
 
     Args:
         input_path (PathLike): the input file

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -865,9 +865,9 @@ def _apply_geooperation(
         input_layerinfo = gfo.get_layerinfo(input_path, input_layer)
         force_output_geometrytype = input_layerinfo.geometrytype.to_multitype.name
 
-    # If the index is still unique, save it as fid column
+    # If the index is still unique, save it to fid column so to_file can save it
     if data_gdf.index.is_unique:
-        data_gdf = data_gdf.reset_index(names=["fid"])
+        data_gdf["fid"] = data_gdf.index
 
     # Use force_multitype, to avoid warnings when some batches contain
     # singletype and some contain multitype geometries

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -795,7 +795,11 @@ def _apply_geooperation(
     # Now go!
     start_time = datetime.now()
     data_gdf = gfo.read_file(
-        path=input_path, layer=input_layer, columns=columns, where=where
+        path=input_path,
+        layer=input_layer,
+        columns=columns,
+        where=where,
+        fid_as_index=True,
     )
 
     # Run operation if data read
@@ -860,6 +864,10 @@ def _apply_geooperation(
     if len(data_gdf) == 0:
         input_layerinfo = gfo.get_layerinfo(input_path, input_layer)
         force_output_geometrytype = input_layerinfo.geometrytype.to_multitype.name
+
+    # If the index is still unique, save it as fid column
+    if data_gdf.index.is_unique:
+        data_gdf = data_gdf.reset_index(names=["fid"])
 
     # Use force_multitype, to avoid warnings when some batches contain
     # singletype and some contain multitype geometries

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -612,6 +612,11 @@ def _apply_geooperation_to_layer(
     if isinstance(force_output_geometrytype, GeometryType):
         force_output_geometrytype = force_output_geometrytype.name
 
+    # Check if we want to preserve the fid in the output
+    preserve_fid = False
+    if not explodecollections and GeofileType(output_path) == GeofileType.GPKG:
+        preserve_fid = True
+
     # Prepare where_to_apply and filter_null_geoms
     if where_post is not None:
         if where_post == "":
@@ -693,6 +698,7 @@ def _apply_geooperation_to_layer(
                     explodecollections=explodecollections,
                     gridsize=gridsize,
                     keep_empty_geoms=keep_empty_geoms,
+                    preserve_fid=preserve_fid,
                     force=force,
                 )
                 future_to_batch_id[future] = batch_id
@@ -741,6 +747,7 @@ def _apply_geooperation_to_layer(
                                 create_spatial_index=False,
                                 force_output_geometrytype=force_output_geometrytype,
                                 where=where_post,
+                                preserve_fid=preserve_fid,
                             )
                             gfo.remove(tmp_partial_output_path)
 
@@ -782,6 +789,7 @@ def _apply_geooperation(
     explodecollections: bool = False,
     gridsize: float = 0.0,
     keep_empty_geoms: bool = True,
+    preserve_fid: bool = False,
     force: bool = False,
 ) -> str:
     # Init
@@ -791,11 +799,6 @@ def _apply_geooperation(
             return message
         else:
             gfo.remove(output_path)
-
-    # Check if we want to preserve the fid in the output
-    preserve_fid = False
-    if not explodecollections and GeofileType(output_path) == GeofileType.GPKG:
-        preserve_fid = True
 
     # Now go!
     start_time = datetime.now()

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -41,7 +41,7 @@ import shapely
 import shapely.geometry as sh_geom
 
 import geofileops as gfo
-from geofileops import fileops
+from geofileops import fileops, GeofileType
 from geofileops.util import _general_util
 from geofileops.util import _geoops_sql
 from geofileops.util import _io_util
@@ -792,6 +792,11 @@ def _apply_geooperation(
         else:
             gfo.remove(output_path)
 
+    # Check if we want to preserve the fid in the output
+    preserve_fid = False
+    if not explodecollections and GeofileType(output_path) == GeofileType.GPKG:
+        preserve_fid = True
+
     # Now go!
     start_time = datetime.now()
     data_gdf = gfo.read_file(
@@ -799,7 +804,7 @@ def _apply_geooperation(
         layer=input_layer,
         columns=columns,
         where=where,
-        fid_as_index=True,
+        fid_as_index=preserve_fid,
     )
 
     # Run operation if data read
@@ -866,7 +871,7 @@ def _apply_geooperation(
         force_output_geometrytype = input_layerinfo.geometrytype.to_multitype.name
 
     # If the index is still unique, save it to fid column so to_file can save it
-    if data_gdf.index.is_unique:
+    if preserve_fid:
         data_gdf["fid"] = data_gdf.index
 
     # Use force_multitype, to avoid warnings when some batches contain

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -321,7 +321,7 @@ def makevalid(
     # Now we can prepare the entire statement
     sql_template = f"""
         SELECT {operation} AS {{geometrycolumn}}
-                {{columns_to_select_str}}
+              {{columns_to_select_str}}
           FROM "{{input_layer}}" layer
          WHERE 1=1
            {{batch_filter}}

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -502,6 +502,11 @@ def _single_layer_vector_operation(
         else:
             gfo.remove(output_path)
 
+    # Determine if fid can be preserved
+    preserve_fid = False
+    if not explodecollections and GeofileType(output_path) == GeofileType.GPKG:
+        preserve_fid = True
+
     # Calculate
     tempdir = _io_util.create_tempdir(f"geofileops/{operation_name.replace(' ', '_')}")
     try:
@@ -689,9 +694,6 @@ def _single_layer_vector_operation(
                 create_spatial_index = False
                 if nb_batches == 1:
                     create_spatial_index = True
-                preserve_fid = True
-                if explodecollections:
-                    preserve_fid = False
                 translate_info = _ogr_util.VectorTranslateInfo(
                     input_path=processing_params.batches[batch_id]["path"],
                     output_path=tmp_partial_output_path,
@@ -761,6 +763,7 @@ def _single_layer_vector_operation(
                         force_output_geometrytype=force_output_geometrytype,
                         where=where_post,
                         create_spatial_index=False,
+                        preserve_fid=preserve_fid,
                     )
                     gfo.remove(tmp_partial_output_path)
 

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -1118,11 +1118,11 @@ def test_to_file_fid_append_to(tmp_path, engine_setter):
     output2_gdf = gfo.read_file(output2_path, fid_as_index=True)
     assert_geodataframe_equal(output2_gdf, test2_gdf.set_index("fid"))
 
-    # Now merge them
-    gfo.copy(output1_path, output_path)
+    # Now merge them, but start with the high fid numbers
+    gfo.copy(output2_path, output_path)
     gfo.rename_layer(output_path, output_path.stem)
     gfo.append_to(
-        output2_path, output_path, dst_layer=output_path.stem, preserve_fid=True
+        output1_path, output_path, dst_layer=output_path.stem, preserve_fid=True
     )
 
     # Prepare expected result

--- a/tests/test_geofileops_singlelayer_ogr.py
+++ b/tests/test_geofileops_singlelayer_ogr.py
@@ -15,6 +15,9 @@ def test_clip_by_geometry(tmp_path, suffix):
     # Prepare test data
     input_path = test_helper.get_testfile("polygon-parcel", suffix=suffix)
 
+    # For Geopackage, also test if fid is properly preserved
+    preserve_fid = True if suffix == ".gpkg" else False
+
     # Do operation
     output_path = tmp_path / f"{input_path.stem}-output{suffix}"
     clip_wkt = (
@@ -35,14 +38,21 @@ def test_clip_by_geometry(tmp_path, suffix):
     assert layerinfo_output.geometrytype == GeometryType.MULTIPOLYGON
 
     # Now check the contents of the result file
-    output_gdf = gfo.read_file(output_path)
-    assert output_gdf["geometry"][0] is not None
+    output_gdf = gfo.read_file(output_path, fid_as_index=preserve_fid)
+    assert output_gdf["geometry"].iloc[0] is not None
+
+    # Check if the fid was properly retained if relevant
+    if preserve_fid:
+        assert output_gdf.iloc[0:2].index.sort_values().tolist() == [1, 10]
 
 
 @pytest.mark.parametrize("suffix", SUFFIXES)
 def test_export_by_bounds(tmp_path, suffix):
     # Prepare test data
     input_path = test_helper.get_testfile("polygon-parcel", suffix=suffix)
+
+    # For Geopackage, also test if fid is properly preserved
+    preserve_fid = True if suffix == ".gpkg" else False
 
     # Do operation
     output_path = tmp_path / f"{input_path.stem}-output{suffix}"
@@ -59,8 +69,12 @@ def test_export_by_bounds(tmp_path, suffix):
     assert layerinfo_output.geometrytype == GeometryType.MULTIPOLYGON
 
     # Now check the contents of the result file
-    output_gdf = gfo.read_file(output_path)
-    assert output_gdf["geometry"][0] is not None
+    output_gdf = gfo.read_file(output_path, fid_as_index=preserve_fid)
+    assert output_gdf["geometry"].iloc[0] is not None
+
+    # Check if the fid was properly retained if relevant
+    if preserve_fid:
+        assert output_gdf.iloc[0:2].index.sort_values().tolist() == [1, 8]
 
 
 def test_warp(tmp_path):


### PR DESCRIPTION
fid's are preserved in gpkg output files if explodecollections is False.