### PR TITLE
TST: Use smaller conda dependency packages where possible in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,16 +42,12 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11"]
         env: ["latest"]
         # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
-        extra: >-
-          nomkl
+        extra: ["nomkl"]
         include:
           - env: minimal
             os: ubuntu-latest
             dev: false
             python: "3.8"
-            # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
-            extra:  >-
-              nomkl
           - env: latest
             os: macos-latest
             dev: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-version: '1.3.1-0'
+          micromamba-version: '1.5.1-0'
           environment-file: ci/envs/${{ matrix.env }}.yml
           cache-environment: true
           create-args: >-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,14 +42,16 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11"]
         env: ["latest"]
         # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
-        extra: ["nomkl"]
+        extra: >-
+          nomkl
         include:
           - env: minimal
             os: ubuntu-latest
             dev: false
             python: "3.8"
             # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
-            extra: ["nomkl"]
+            extra:  >-
+              nomkl
           - env: latest
             os: macos-latest
             dev: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,11 +41,15 @@ jobs:
         dev: [false]
         python: ["3.8", "3.9", "3.10", "3.11"]
         env: ["latest"]
+        # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
+        extra: nomkl
         include:
           - env: minimal
             os: ubuntu-latest
             dev: false
             python: "3.8"
+            # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
+            extra: nomkl
           - env: latest
             os: macos-latest
             dev: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,14 +42,14 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11"]
         env: ["latest"]
         # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
-        extra: "nomkl"
+        extra: ["nomkl"]
         include:
           - env: minimal
             os: ubuntu-latest
             dev: false
             python: "3.8"
             # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
-            extra: "nomkl"
+            extra: ["nomkl"]
           - env: latest
             os: macos-latest
             dev: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,14 +42,14 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11"]
         env: ["latest"]
         # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
-        extra: nomkl
+        extra: "nomkl"
         include:
           - env: minimal
             os: ubuntu-latest
             dev: false
             python: "3.8"
             # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
-            extra: nomkl
+            extra: "nomkl"
           - env: latest
             os: macos-latest
             dev: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
   `select_two_layers` (#283)
 - Improve handling + tests regarding empty input layers/NULL geometries (#320)
 - Many small improvements to logging, documentation, error messages,... (#321, #366,...)
-- Speed up tests by reducing conda dependency footprint (use `geopandas-base`, `nomkl`) (#377)
+- Use smaller footprint conda packages for tests (use `geopandas-base`, `nomkl`) (#377)
 - Use ruff instead of flake8 for linting (#317)
 
 ### Bugs fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
   `select_two_layers` (#283)
 - Improve handling + tests regarding empty input layers/NULL geometries (#320)
 - Many small improvements to logging, documentation, error messages,... (#321, #366,...)
-- Speed up tests by reducing conda dependency footprint (use `geopandas-base`, `nomkl`) (#)
+- Speed up tests by reducing conda dependency footprint (use `geopandas-base`, `nomkl`) (#377)
 - Use ruff instead of flake8 for linting (#317)
 
 ### Bugs fixed
@@ -46,7 +46,6 @@
 ### Deprecations and compatibility notes
 
 - Drop support for shapely1 (#329, #338)
-- Depend on `geopandas-base` instead on `geopandas` to reduce footprint when using conda (#)
 - `makevalid` parameter `precision` is renamed to `gridsize` as this is the typical
   terminology in other libraries (#273)
 - parameter `area_inters_column_name` in `export_by_location` now defaults to `None`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   `select_two_layers` (#283)
 - Improve handling + tests regarding empty input layers/NULL geometries (#320)
 - Many small improvements to logging, documentation, error messages,... (#321, #366,...)
+- Speed up tests by reducing conda dependency footprint (use `geopandas-base`, `nomkl`) (#)
 - Use ruff instead of flake8 for linting (#317)
 
 ### Bugs fixed
@@ -45,6 +46,7 @@
 ### Deprecations and compatibility notes
 
 - Drop support for shapely1 (#329, #338)
+- Depend on `geopandas-base` instead on `geopandas` to reduce footprint when using conda (#)
 - `makevalid` parameter `precision` is renamed to `gridsize` as this is the typical
   terminology in other libraries (#273)
 - parameter `area_inters_column_name` in `export_by_location` now defaults to `None`

--- a/ci/envs/latest.yml
+++ b/ci/envs/latest.yml
@@ -13,8 +13,8 @@ dependencies:
   - numpy
   - pandas
   - psutil
-  #- pygeoops >=0.3,<0.4
-  - pyogrio
+  - pygeoops >=0.3,<0.4
+  - pyogrio >=0.5
   - pyproj
   - shapely >=2,<2.1
   - topojson
@@ -22,5 +22,4 @@ dependencies:
   - pytest
   - pytest-cov
   - pip:
-    - pygeoops ==0.3.0a5
     - simplification

--- a/ci/envs/latest.yml
+++ b/ci/envs/latest.yml
@@ -1,13 +1,15 @@
-name: test
+name: geofileops-latest
 channels:
   - conda-forge
 dependencies:
+  - python
   - pip
   # required
   - cloudpickle
   - fiona
   - gdal
-  - geopandas >=0.12
+  - geopandas-base >=0.12
+  - nomkl  # Avoid mkl from being installed as it is huge -> openblas will be used
   - numpy
   - pandas
   - psutil

--- a/ci/envs/latest.yml
+++ b/ci/envs/latest.yml
@@ -9,7 +9,7 @@ dependencies:
   - fiona
   - gdal
   - geopandas-base >=0.12
-  - nomkl  # Avoid mkl from being installed as it is huge -> openblas will be used
+  # - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy
   - pandas
   - psutil

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -9,7 +9,7 @@ dependencies:
   - fiona
   - gdal =3.6.3  # released 2023-03-13
   - geopandas-base =0.12  # released 2022-10-24
-  - nomkl  # Avoid mkl from being installed as it is huge -> openblas will be used
+  # - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy =1.21  # released 2021-06-22
   - pandas =1.1  # released 2020-06-28
   - psutil

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -13,7 +13,7 @@ dependencies:
   - numpy =1.21  # released 2021-06-22
   - pandas =1.1  # released 2020-06-28
   - psutil
-  #- pygeoops >=0.3,<0.4  # released 2023-08-08
+  - pygeoops =0.3  # released 2023-09-08
   - pygeos
   - pyogrio =0.5.1  # released 2023-01-26
   - pyproj =3.4  # released 2022-09-10

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -1,13 +1,15 @@
-name: test
+name: geofileops-minimal
 channels:
   - conda-forge
 dependencies:
+  - python
   - pip
   # required
   - cloudpickle
   - fiona
   - gdal =3.6.3  # released 2023-03-13
-  - geopandas =0.12  # released 2022-10-24
+  - geopandas-base =0.12  # released 2022-10-24
+  - nomkl  # Avoid mkl from being installed as it is huge -> openblas will be used
   - numpy =1.21  # released 2021-06-22
   - pandas =1.1  # released 2020-06-28
   - psutil

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -9,7 +9,7 @@ dependencies:
   - fiona
   - gdal =3.6.3  # released 2023-03-13
   - geopandas-base =0.12  # released 2022-10-24
-  # - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
+  - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy =1.21  # released 2021-06-22
   - pandas =1.1  # released 2020-06-28
   - psutil

--- a/ci/envs/readthedocs.yml
+++ b/ci/envs/readthedocs.yml
@@ -1,4 +1,4 @@
-name: geofileopsdev
+name: geofileops-doc
 channels:
   - conda-forge
 dependencies:
@@ -8,7 +8,8 @@ dependencies:
   - cloudpickle
   - fiona
   - gdal
-  - geopandas >=0.12
+  - geopandas-base >=0.12
+  - nomkl  # Avoid mkl from being installed as it is huge -> openblas will be used
   - numpy
   - pandas
   - psutil

--- a/ci/envs/readthedocs.yml
+++ b/ci/envs/readthedocs.yml
@@ -13,8 +13,8 @@ dependencies:
   - numpy
   - pandas
   - psutil
-  #- pygeoops >=0.3,<0.4
-  - pyogrio
+  - pygeoops >=0.3,<0.4
+  - pyogrio >=0.5
   - pyproj
   - shapely >=2,<2.1
   - topojson
@@ -23,6 +23,5 @@ dependencies:
   - sphinx<6
   - pydata-sphinx-theme
   - pip:
-    - pygeoops ==0.3.0a5
     - sphinx-automodapi ==0.13
     - simplification

--- a/ci/envs/readthedocs.yml
+++ b/ci/envs/readthedocs.yml
@@ -9,7 +9,7 @@ dependencies:
   - fiona
   - gdal
   - geopandas-base >=0.12
-  - nomkl  # Avoid mkl from being installed as it is huge -> openblas will be used
+  - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy
   - pandas
   - psutil

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
   - gdal >=3.6.4
   - geopandas-base >=0.12
   - libspatialite >=5.0
-  - nomkl  # Avoid mkl from being installed as it is huge -> openblas will be used
+  # - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy
   - pandas
   - psutil

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,8 +8,9 @@ dependencies:
   - cloudpickle
   - fiona
   - gdal >=3.6.4
-  - geopandas >=0.12
+  - geopandas-base >=0.12
   - libspatialite >=5.0
+  - nomkl  # Avoid mkl from being installed as it is huge -> openblas will be used
   - numpy
   - pandas
   - psutil

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,7 @@ name: geofileops-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python =3.11
   - pip
   # required
   - cloudpickle
@@ -14,8 +14,8 @@ dependencies:
   - numpy
   - pandas
   - psutil
-  #- pygeoops >=0.3,<0.4
-  - pyogrio
+  - pygeoops >=0.3,<0.4
+  - pyogrio >=0.5
   - pyproj
   - shapely >=2,<2.1
   # optional
@@ -32,7 +32,6 @@ dependencies:
   # docs
   - pydata-sphinx-theme
   - pip:
-    - pygeoops ==0.3.0a5
     - sphinx-automodapi==0.13
     # optional
     - simplification


### PR DESCRIPTION
Following main changes:
* `geopandas` -> `geopandas-base`
    * once tests are OK -> conda feedstock can be changed.
* `pygeoops`: use release (conda) version again 
* use `nomkl` for linux builds:
    * if specified in the depencencies, it avoids the mkl numerical library to be used by numpy, which is huge. Instead openblas will be installed.
    * for the linux builds this works fine, but running the tests on MacOS and Windows takes double te time.
    * Conclusion: only for linux!