### PR TITLE
Fix erase not giving correct results in some cases

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,7 @@ name: geofileops-dev
 channels:
   - conda-forge
 dependencies:
-  - python =3.11
+  - python =3.10
   - pip
   # required
   - cloudpickle

--- a/geofileops/util/_sqlite_userdefined.py
+++ b/geofileops/util/_sqlite_userdefined.py
@@ -205,9 +205,10 @@ def gfo_subdivide(geom_wkb: bytes, coords: int = 1000):
         if len(result) == 1:
             return shapely.to_wkb(result[0])
 
-        # Explode because they will be exploded anyway by spatialite.ST_Collect and
-        # spatialite.ST_AsBinary and/or spatialite.ST_GeomFromWkb don't seem to handle
-        # nested collections well.
+        # Explode because
+        #   - they will be exploded anyway by spatialite.ST_Collect
+        #   - spatialite.ST_AsBinary and/or spatialite.ST_GeomFromWkb don't seem to
+        #     handle nested collections well.
         return shapely.to_wkb(
             shapely.GeometryCollection(shapely.get_parts(result).tolist())
         )

--- a/geofileops/util/_sqlite_userdefined.py
+++ b/geofileops/util/_sqlite_userdefined.py
@@ -2,8 +2,8 @@
 import logging
 from typing import Optional
 
-import shapely
 import pygeoops
+import shapely
 
 # from pygeoops import _difference as _difference
 # from pygeoops import _paramvalidation as paramvalidation
@@ -205,7 +205,12 @@ def gfo_subdivide(geom_wkb: bytes, coords: int = 1000):
         if len(result) == 1:
             return shapely.to_wkb(result[0])
 
-        return shapely.to_wkb(shapely.GeometryCollection(result.tolist()))
+        # Explode because they will be exploded anyway by spatialite.ST_Collect and
+        # spatialite.ST_AsBinary and/or spatialite.ST_GeomFromWkb don't seem to handle
+        # nested collections well.
+        return shapely.to_wkb(
+            shapely.GeometryCollection(shapely.get_parts(result).tolist())
+        )
 
     except Exception as ex:  # pragma: no cover
         # ex.with_traceback()

--- a/tests/test_spatialite.py
+++ b/tests/test_spatialite.py
@@ -3,6 +3,7 @@ Tests for functionalities in ogr_util.
 """
 
 import pytest
+import shapely.geometry as sh_geom
 
 import geofileops as gfo
 from tests import test_helper
@@ -10,13 +11,15 @@ from tests import test_helper
 
 @pytest.mark.skipif(
     not test_helper.RUNS_LOCAL,
-    reason="Don't this run on CI: just to followup odd behaviour in spatialite.",
+    reason="Don't this run on CI: just to document this behaviour.",
 )
 def test_st_difference_null(tmp_path):
     """
-    ST_difference returns NULL when 2nd argument is NULL, which is odd.
+    ST_difference returns NULL when 2nd argument is NULL.
 
-    In several spatial operations IIF statements are used to avoid this behaviour.
+    This is the normal treatment of NULL values: `SELECT (1-NULL)` also results in NULL.
+
+    In several spatial operations IIF statements are used to handle this situation.
     """
     input_path = test_helper.get_testfile(testfile="polygon-parcel")
 
@@ -31,3 +34,32 @@ def test_st_difference_null(tmp_path):
     input_gdf = gfo.read_file(input_path)
     output_gdf = gfo.read_file(output_path)
     assert len(input_gdf) == len(output_gdf)
+
+
+@pytest.mark.skipif(
+    not test_helper.RUNS_LOCAL,
+    reason="Don't this run on CI: just to document this behaviour.",
+)
+@pytest.mark.parametrize("ogr_type", ["WKB", "WKT"])
+def test_nested_collections(ogr_type):
+    """
+    ST_difference returns NULL when 2nd argument is NULL.
+
+    This is the normal treatment of NULL values: `SELECT (1-NULL)` also results in NULL.
+
+    In several spatial operations IIF statements are used to handle this situation.
+    """
+    # Prepare test data
+    input_path = test_helper.get_testfile(testfile="polygon-parcel")
+    collection = sh_geom.GeometryCollection(
+        [test_helper.TestData.multipolygon, test_helper.TestData.polygon_no_islands]
+    )
+
+    # Test
+    if ogr_type == "WKB":
+        sql_stmt = f"SELECT ST_GeomFromText('{collection.wkt}')"
+    elif ogr_type == "WKT":
+        sql_stmt = f"SELECT ST_GeomFromWKB(x'{collection.wkb_hex}')"
+
+    test_gdf = gfo.read_file(input_path, sql_stmt=sql_stmt)
+    assert test_gdf.geometry[0].wkt == collection.wkt


### PR DESCRIPTION
For some cases erase now doesn't seem to do any erasing at all.

Specifically, if multi-type geometries are subdivided and they result in multi-geometries after subdividing, then (parts of) the multi-geometries are ignored for the difference being applied because spatialite.ST_GeomFromWkb throws them away.

A bug request was filed in the spatialite forum: [bug post](https://groups.google.com/g/spatialite-users/c/GW-Ed0SL81Y/m/yUmh5ZNKBAAJ?utm_medium=email&utm_source=footer)

Note: this fixes a bug in currently unreleased changes... so isn't included in the changelog.