### PR TITLE
Disable ci environment caching as it seems to cache ad infinitum + support gdal 3.7.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,6 @@ jobs:
         with:
           micromamba-version: '1.5.1-0'
           environment-file: ci/envs/${{ matrix.env }}.yml
-          cache-environment: true
           create-args: >-
             python=${{ matrix.python }}
             ${{ matrix.extra }}

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -248,7 +248,8 @@ def vector_translate(
             output_geometrytypes.append(force_output_geometrytype.name)
         else:
             output_geometrytypes.append(force_output_geometrytype)
-    output_geometrytypes.append("PROMOTE_TO_MULTI")
+    else:
+        output_geometrytypes.append("PROMOTE_TO_MULTI")
     if transaction_size is not None:
         args.extend(["-gt", str(transaction_size)])
     if preserve_fid is not None:


### PR DESCRIPTION
- if `cache-environment: true` is specified for action `mamba-org/setup-micromamba@v1`, the environment seems to be cached ad infinitum... so there are never new versions of dependencies -> remove cache.
   - Issue is reported here: https://github.com/mamba-org/setup-micromamba/issues/50
- because of the above, gdal 3.7.2 is now installed, and it behaves differently if multiple output_geometry_type's are specified: with combination of "POINT" and "PROMOTE_TO_MULTI" gdal now actually applies "PROMOTE_TO_MULTI", so MULTIPOINTs are  saved in a POINT layer wich gives issues later on: when such a layer is input layer in vecor_translate, an error is thrown.