### PR TITLE
Fix spatialite version to st 5.1

### DIFF
--- a/ci/envs/latest.yml
+++ b/ci/envs/latest.yml
@@ -9,6 +9,7 @@ dependencies:
   - fiona
   - gdal >=3.6.3
   - geopandas-base >=0.12
+  - libspatialite >=5.0,<5.1  # knn index replaced by knn2 in 5.1
   # - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy
   - pandas

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -9,6 +9,7 @@ dependencies:
   - fiona
   - gdal =3.6.3  # released 2023-03-13
   - geopandas-base =0.12  # released 2022-10-24
+  - libspatialite =5.0  #  knn index replaced by knn2 in 5.1
   - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy =1.21  # released 2021-06-22
   - pandas =1.1  # released 2020-06-28

--- a/ci/envs/readthedocs.yml
+++ b/ci/envs/readthedocs.yml
@@ -9,6 +9,7 @@ dependencies:
   - fiona
   - gdal >=3.6.3
   - geopandas-base >=0.12
+  - libspatialite >=5.0,<5.1  # knn index replaced by knn2 in 5.1
   - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy
   - pandas

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setuptools.setup(
         "pyogrio",
         "pyproj",
         "shapely>=2,<2.1",
+        "libspatialite>=5.0,<5.1",
         "topojson<2",
     ],
     extras_require={"full": ["simplification"]},


### PR DESCRIPTION
knn index replaced by knn2 in 5.1, which breaks `join_nearest`

reference #384