### PR TITLE
Remove libspatialite as pip requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setuptools.setup(
         "pyogrio",
         "pyproj",
         "shapely>=2,<2.1",
-        "libspatialite>=5.0,<5.1",
         "topojson<2",
     ],
     extras_require={"full": ["simplification"]},


### PR DESCRIPTION
libspatialite doesn't exist as pip package