### PR TITLE
Rename split to identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Improve performance of `clip`: 3x faster for typical data (#358)
 - Improve performance of `export_by_location`, especially when `area_inters_column_name`
   and `min_area_intersect` are `None`: a lot faster + 10x less memory usage (#370)
-- Improve performance of `erase`, `split`, `symmetric difference` and `union` by
+- Improve performance of `erase`, `identity`, `symmetric difference` and `union` by
   applying on-the-fly subdividing of complex geometries to speed up processing. The new
   parameter `subdivide_coords` can be used to control the feature. For files with very
   large input geometries, up to 100x faster + 10x less memory usage.
@@ -313,12 +313,12 @@ In this release, the main change is a new operation that has been added: nearest
 ## 0.2.2 (2021-05-05)
 
 Improved performance for all operations that involve overlays between 2 layers 
-(intersect, union, split,...).
+(intersect, union, identity/split,...).
 
 ### Improvements
 
 - Improved performance for all operations that involve overlays between 2 
-  layers (intersect, union, split,...). Especially if the input files are in 
+  layers (intersect, union, identity/split,...). Especially if the input files are in 
   Geopackage format the improvement should be significant because in this case 
   the input data isn't copied to temp files anymore.
 - Added the method geofile.execute_sql() to be able to execute a DML/DDL sql 
@@ -327,7 +327,7 @@ Improved performance for all operations that involve overlays between 2 layers
 
 ### Bugs fixed
 
-- In the split and union operations, in some cases (mainly when input layers 
+- In the identity/split and union operations, in some cases (mainly when input layers 
   had self-intersections) intersections in the output were unioned instead of 
   keeping them as seperate rows.
 - When using an input file with multiple layers (eg. a geopackage), this 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,22 +46,24 @@
 - Fix "json" aggregate column handling in dissolve on line and point input files gives
   wrong results (#257)
 - Fix error in `read_file` when `read_geometry=False` and `columns` specified (#393)
-- Fix error in `copy_layer` with `explodecollections` on some input files (#395)
+- Fix error in `copy_layer`/`convert` with `explodecollections` on some input files
+  (#395)
 
 ### Deprecations and compatibility notes
 
 - Drop support for shapely1 (#329, #338)
-- `makevalid` parameter `precision` is renamed to `gridsize` as this is the typical
+- Parameter `precision` of `makevalid` is renamed to `gridsize` as this is the typical
   terminology in other libraries (#273)
-- parameter `area_inters_column_name` in `export_by_location` now defaults to `None`
+- Parameter `area_inters_column_name` in `export_by_location` now defaults to `None`
   instead of "area_inters" (#370)
-- `keep_empty_geoms` parameters are added with default value `False` for most operations
+- Parameter `keep_empty_geoms` is added with default value `False` for most operations
   as this was the default behaviour for those operations in the past. This will be
   changed to `True` in a future version. This is also explained in a futurewarning (#262)
-- removed the long-deprecated functions `get_driver`, `get_driver_for_ext`,
+- Removed the long-deprecated functions `get_driver`, `get_driver_for_ext`,
   `to_multi_type` and `to_generaltypeid`  (#276)
-- rename and deprecate `convert` to `copy_layer` (#310)
-- removed the long-deprecated `vector_util`, `geofileops.geofile` and
+- Deprecate `convert` and rename to `copy_layer` (#310)
+- Deprecate `split` and rename to `identity` #397
+- Removed the long-deprecated `vector_util`, `geofileops.geofile` and
   `geofileops.geofileops` namespaces (#276)
 - Remove `geometry_util`, `geoseries_util` and `grid_util` (#339):
    - Most functions were moved to `pygeoops` because they are generally reusable.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -44,7 +44,7 @@ Spatial operations on two layers
    join_by_location
    join_nearest
    select_two_layers
-   split
+   identity
    symmetric_difference
    union
 

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -1669,6 +1669,154 @@ def export_by_distance(
     )
 
 
+def identity(
+    input1_path: Union[str, "os.PathLike[Any]"],
+    input2_path: Union[str, "os.PathLike[Any]"],
+    output_path: Union[str, "os.PathLike[Any]"],
+    input1_layer: Optional[str] = None,
+    input1_columns: Optional[List[str]] = None,
+    input1_columns_prefix: str = "l1_",
+    input2_layer: Optional[str] = None,
+    input2_columns: Optional[List[str]] = None,
+    input2_columns_prefix: str = "l2_",
+    output_layer: Optional[str] = None,
+    explodecollections: bool = False,
+    gridsize: float = 0.0,
+    where_post: Optional[str] = None,
+    nb_parallel: int = -1,
+    batchsize: int = -1,
+    subdivide_coords: int = 1000,
+    force: bool = False,
+):
+    """
+    Intersection of the input layers, but retain the non-intersecting parts of input1.
+
+    The result is the equivalent of an intersect between the two layers + layer
+    1 erased with layer 2.
+
+    Args:
+        input1_path (PathLike): the 1st input file
+        input2_path (PathLike): the 2nd input file
+        output_path (PathLike): the file to write the result to
+        input1_layer (str, optional): input layer name. Optional if the
+            file only contains one layer. Defaults to None.
+        input1_columns (List[str], optional): list of columns to retain. If None, all
+            standard columns are retained. In addition to standard columns, it is also
+            possible to specify "fid", a unique index available in all input files. Note
+            that the "fid" will be aliased even if input1_columns_prefix is "", eg. to
+            "fid_1". Defaults to None.
+        input1_columns_prefix (str, optional): prefix to use in the column aliases.
+            Defaults to "l1_".
+        input2_layer (str, optional): input layer name. Optional if the
+            file only contains one layer. Defaults to None.
+        input2_columns (List[str], optional): columns to select. If None is specified,
+            all columns are selected. As explained for input1_columns, it is also
+            possible to specify "fid". Defaults to None.
+        input2_columns_prefix (str, optional): prefix to use in the column aliases.
+            Defaults to "l2_".
+        output_layer (str, optional): output layer name. If None, the output_path stem
+            is used. Defaults to None.
+        explodecollections (bool, optional): True to convert all multi-geometries to
+            singular ones after the dissolve. Defaults to False.
+        gridsize (float, optional): the size of the grid the coordinates of the ouput
+            will be rounded to. Eg. 0.001 to keep 3 decimals. Value 0.0 doesn't change
+            the precision. Defaults to 0.0.
+        where_post (str, optional): sql filter to apply after all other processing,
+            including e.g. explodecollections. It should be in sqlite syntax and
+            |spatialite_reference_link| functions can be used. Defaults to None.
+        nb_parallel (int, optional): the number of parallel processes to use.
+            Defaults to -1: use all available processors.
+        batchsize (int, optional): indicative number of rows to process per
+            batch. A smaller batch size, possibly in combination with a
+            smaller nb_parallel, will reduce the memory usage.
+            Defaults to -1: (try to) determine optimal size automatically.
+        subdivide_coords (int, optional): the input geometries will be subdivided to
+            parts with about subdivide_coords coordinates during processing which can
+            offer a large speed up for complex geometries. Subdividing can result in
+            extra collinear points being added to the boundaries of the output. If < 0,
+            no subdividing is applied. Defaults to 1000.
+        force (bool, optional): overwrite existing output file(s).
+            Defaults to False.
+
+    .. |spatialite_reference_link| raw:: html
+
+        <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
+
+    """  # noqa: E501
+    logger.info(
+        f"Start identity between {input1_path} and {input2_path} to {output_path}"
+    )
+    return _geoops_sql.identity(
+        input1_path=Path(input1_path),
+        input2_path=Path(input2_path),
+        output_path=Path(output_path),
+        input1_layer=input1_layer,
+        input1_columns=input1_columns,
+        input1_columns_prefix=input1_columns_prefix,
+        input2_layer=input2_layer,
+        input2_columns=input2_columns,
+        input2_columns_prefix=input2_columns_prefix,
+        output_layer=output_layer,
+        explodecollections=explodecollections,
+        gridsize=gridsize,
+        where_post=where_post,
+        nb_parallel=nb_parallel,
+        batchsize=batchsize,
+        subdivide_coords=subdivide_coords,
+        force=force,
+    )
+
+
+def split(
+    input1_path: Union[str, "os.PathLike[Any]"],
+    input2_path: Union[str, "os.PathLike[Any]"],
+    output_path: Union[str, "os.PathLike[Any]"],
+    input1_layer: Optional[str] = None,
+    input1_columns: Optional[List[str]] = None,
+    input1_columns_prefix: str = "l1_",
+    input2_layer: Optional[str] = None,
+    input2_columns: Optional[List[str]] = None,
+    input2_columns_prefix: str = "l2_",
+    output_layer: Optional[str] = None,
+    explodecollections: bool = False,
+    gridsize: float = 0.0,
+    where_post: Optional[str] = None,
+    nb_parallel: int = -1,
+    batchsize: int = -1,
+    subdivide_coords: int = 1000,
+    force: bool = False,
+):
+    """
+    DEPRECATED: please use identity.
+    """
+    warnings.warn(  # pragma: no cover
+        "split() is deprecated because it was renamed to identity(). "
+        "Will be removed in a future version",
+        FutureWarning,
+        stacklevel=2,
+    )
+    logger.info(f"Start split between {input1_path} and {input2_path} to {output_path}")
+    return _geoops_sql.identity(
+        input1_path=Path(input1_path),
+        input2_path=Path(input2_path),
+        output_path=Path(output_path),
+        input1_layer=input1_layer,
+        input1_columns=input1_columns,
+        input1_columns_prefix=input1_columns_prefix,
+        input2_layer=input2_layer,
+        input2_columns=input2_columns,
+        input2_columns_prefix=input2_columns_prefix,
+        output_layer=output_layer,
+        explodecollections=explodecollections,
+        gridsize=gridsize,
+        where_post=where_post,
+        nb_parallel=nb_parallel,
+        batchsize=batchsize,
+        subdivide_coords=subdivide_coords,
+        force=force,
+    )
+
+
 def intersect(
     input1_path: Union[str, "os.PathLike[Any]"],
     input2_path: Union[str, "os.PathLike[Any]"],
@@ -2299,106 +2447,6 @@ def symmetric_difference(
         f"to {output_path}"
     )
     return _geoops_sql.symmetric_difference(
-        input1_path=Path(input1_path),
-        input2_path=Path(input2_path),
-        output_path=Path(output_path),
-        input1_layer=input1_layer,
-        input1_columns=input1_columns,
-        input1_columns_prefix=input1_columns_prefix,
-        input2_layer=input2_layer,
-        input2_columns=input2_columns,
-        input2_columns_prefix=input2_columns_prefix,
-        output_layer=output_layer,
-        explodecollections=explodecollections,
-        gridsize=gridsize,
-        where_post=where_post,
-        nb_parallel=nb_parallel,
-        batchsize=batchsize,
-        subdivide_coords=subdivide_coords,
-        force=force,
-    )
-
-
-def split(
-    input1_path: Union[str, "os.PathLike[Any]"],
-    input2_path: Union[str, "os.PathLike[Any]"],
-    output_path: Union[str, "os.PathLike[Any]"],
-    input1_layer: Optional[str] = None,
-    input1_columns: Optional[List[str]] = None,
-    input1_columns_prefix: str = "l1_",
-    input2_layer: Optional[str] = None,
-    input2_columns: Optional[List[str]] = None,
-    input2_columns_prefix: str = "l2_",
-    output_layer: Optional[str] = None,
-    explodecollections: bool = False,
-    gridsize: float = 0.0,
-    where_post: Optional[str] = None,
-    nb_parallel: int = -1,
-    batchsize: int = -1,
-    subdivide_coords: int = 1000,
-    force: bool = False,
-):
-    """
-    Split the features in input1 with all features in input2.
-
-    The result is the equivalent of an intersect between the two layers + layer
-    1 erased with layer 2.
-
-    Alternative names:
-        - ArcMap, SAGA: identity
-        - GeoPandas: overlay(how="identity")
-
-    Args:
-        input1_path (PathLike): the 1st input file
-        input2_path (PathLike): the 2nd input file
-        output_path (PathLike): the file to write the result to
-        input1_layer (str, optional): input layer name. Optional if the
-            file only contains one layer. Defaults to None.
-        input1_columns (List[str], optional): list of columns to retain. If None, all
-            standard columns are retained. In addition to standard columns, it is also
-            possible to specify "fid", a unique index available in all input files. Note
-            that the "fid" will be aliased even if input1_columns_prefix is "", eg. to
-            "fid_1". Defaults to None.
-        input1_columns_prefix (str, optional): prefix to use in the column aliases.
-            Defaults to "l1_".
-        input2_layer (str, optional): input layer name. Optional if the
-            file only contains one layer. Defaults to None.
-        input2_columns (List[str], optional): columns to select. If None is specified,
-            all columns are selected. As explained for input1_columns, it is also
-            possible to specify "fid". Defaults to None.
-        input2_columns_prefix (str, optional): prefix to use in the column aliases.
-            Defaults to "l2_".
-        output_layer (str, optional): output layer name. If None, the output_path stem
-            is used. Defaults to None.
-        explodecollections (bool, optional): True to convert all multi-geometries to
-            singular ones after the dissolve. Defaults to False.
-        gridsize (float, optional): the size of the grid the coordinates of the ouput
-            will be rounded to. Eg. 0.001 to keep 3 decimals. Value 0.0 doesn't change
-            the precision. Defaults to 0.0.
-        where_post (str, optional): sql filter to apply after all other processing,
-            including e.g. explodecollections. It should be in sqlite syntax and
-            |spatialite_reference_link| functions can be used. Defaults to None.
-        nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
-        batchsize (int, optional): indicative number of rows to process per
-            batch. A smaller batch size, possibly in combination with a
-            smaller nb_parallel, will reduce the memory usage.
-            Defaults to -1: (try to) determine optimal size automatically.
-        subdivide_coords (int, optional): the input geometries will be subdivided to
-            parts with about subdivide_coords coordinates during processing which can
-            offer a large speed up for complex geometries. Subdividing can result in
-            extra collinear points being added to the boundaries of the output. If < 0,
-            no subdividing is applied. Defaults to 1000.
-        force (bool, optional): overwrite existing output file(s).
-            Defaults to False.
-
-    .. |spatialite_reference_link| raw:: html
-
-        <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
-
-    """  # noqa: E501
-    logger.info(f"Start split between {input1_path} and {input2_path} to {output_path}")
-    return _geoops_sql.split(
         input1_path=Path(input1_path),
         input2_path=Path(input2_path),
         output_path=Path(output_path),

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -1789,13 +1789,15 @@ def split(
     """
     DEPRECATED: please use identity.
     """
-    warnings.warn(  # pragma: no cover
+    warnings.warn(
         "split() is deprecated because it was renamed to identity(). "
         "Will be removed in a future version",
         FutureWarning,
         stacklevel=2,
     )
-    logger.info(f"Start split between {input1_path} and {input2_path} to {output_path}")
+    logger.info(
+        f"Start identity between {input1_path} and {input2_path} to {output_path}"
+    )
     return _geoops_sql.identity(
         input1_path=Path(input1_path),
         input2_path=Path(input2_path),

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -1858,7 +1858,7 @@ def identity(
         input2_path=input2_path,
         output_path=output_path,
         sql_template=sql_template,
-        operation_name="split",
+        operation_name="identity",
         input1_layer=input1_layer,
         input1_columns=input1_columns,
         input1_columns_prefix=input1_columns_prefix,
@@ -2009,10 +2009,10 @@ def union(
     subdivide_coords: int = 1000,
     force: bool = False,
 ):
-    # A union can be simulated by doing a "split" of input1 and input2 and
+    # A union can be simulated by doing an "identity" of input1 and input2 and
     # then append the result of an erase of input2 with input1...
 
-    # Because the calculations in split and erase will be towards temp files,
+    # Because the calculations in identity and erase will be towards temp files,
     # we need to do some additional init + checks here...
     if force is False and output_path.exists():
         return
@@ -2022,12 +2022,12 @@ def union(
     start_time = datetime.now()
     tempdir = _io_util.create_tempdir("geofileops/union")
     try:
-        # First split input1 with input2 to a temporary output gfo...
-        split_output_path = tempdir / "split_output.gpkg"
+        # First apply identity of input1 with input2 to a temporary output file...
+        identity_output_path = tempdir / "identity_output.gpkg"
         identity(
             input1_path=input1_path,
             input2_path=input2_path,
-            output_path=split_output_path,
+            output_path=identity_output_path,
             input1_layer=input1_layer,
             input1_columns=input1_columns,
             input1_columns_prefix=input1_columns_prefix,
@@ -2069,17 +2069,17 @@ def union(
         # Now append
         _append_to_nolock(
             src=erase_output_path,
-            dst=split_output_path,
+            dst=identity_output_path,
             src_layer=output_layer,
             dst_layer=output_layer,
         )
 
         # Convert or add spatial index
-        tmp_output_path = split_output_path
-        if split_output_path.suffix != output_path.suffix:
+        tmp_output_path = identity_output_path
+        if identity_output_path.suffix != output_path.suffix:
             # Output file should be in different format, so convert
             tmp_output_path = tempdir / output_path.name
-            gfo.copy_layer(src=split_output_path, dst=tmp_output_path)
+            gfo.copy_layer(src=identity_output_path, dst=tmp_output_path)
         else:
             # Create spatial index
             gfo.create_spatial_index(path=tmp_output_path, layer=output_layer)

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -1723,7 +1723,7 @@ def select_two_layers(
     )
 
 
-def split(
+def identity(
     input1_path: Path,
     input2_path: Path,
     output_path: Path,
@@ -2024,7 +2024,7 @@ def union(
     try:
         # First split input1 with input2 to a temporary output gfo...
         split_output_path = tempdir / "split_output.gpkg"
-        split(
+        identity(
             input1_path=input1_path,
             input2_path=input2_path,
             output_path=split_output_path,


### PR DESCRIPTION
`split` is called `identity` in ArcMap, Saga and GeoPandas... and `split` is specific for geofileops, so better to align to the other libraries for convenience (even though I don't understand why it is called "Identity").