### PR TITLE
Improve logging: use geo operation being executed as `logger name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Improve handling of "SELECT * ..." style queries in `select` and `select_two_layers`
   (#283)
 - Improve handling + tests regarding empty input layers/NULL geometries (#320)
+- Improve logging: use geo operation being executed as `logger name` (#410)
 - Many small improvements to logging, documentation, (gdal)error messages,...
   (#321, #366, #394,...)
 - Use smaller footprint conda packages for tests (use `geopandas-base`, `nomkl`) (#377)

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -89,7 +89,7 @@ def apply(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -199,7 +199,7 @@ def buffer(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -430,7 +430,7 @@ def convexhull(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -666,7 +666,7 @@ def dissolve(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -797,7 +797,7 @@ def isvalid(
         validate_attribute_data (bool, optional): True to validate if all attribute data
             can be read. Defaults to False.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -891,7 +891,7 @@ def makevalid(
             can be read. Raises an exception if an error is found, as this type of error
             cannot be fixed using makevalid. Defaults to False.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -1203,7 +1203,7 @@ def simplify(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -1321,7 +1321,7 @@ def clip(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -1406,7 +1406,7 @@ def erase(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -1494,7 +1494,7 @@ def export_by_location(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -1572,7 +1572,7 @@ def export_by_distance(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -1663,7 +1663,7 @@ def identity(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -1857,7 +1857,7 @@ def intersection(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -1978,7 +1978,7 @@ def join_by_location(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -2063,7 +2063,7 @@ def join_nearest(
         output_layer (str, optional): output layer name. If None, the output_path stem
             is used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -2231,7 +2231,7 @@ def select_two_layers(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -2363,7 +2363,7 @@ def symmetric_difference(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduc
@@ -2383,8 +2383,8 @@ def symmetric_difference(
 
     """  # noqa: E501
     logger.info(
-        f"Start symmetric_difference of {input1_path} and {input2_path} "
-        f"to {output_path}"
+        f"symmetric_difference: start, with input1: {input1_path}, "
+        f"input2 {input2_path}, output: {output_path}"
     )
     return _geoops_sql.symmetric_difference(
         input1_path=Path(input1_path),
@@ -2463,7 +2463,7 @@ def union(
             including e.g. explodecollections. It should be in sqlite syntax and
             |spatialite_reference_link| functions can be used. Defaults to None.
         nb_parallel (int, optional): the number of parallel processes to use.
-            Defaults to -1: use all available processors.
+            Defaults to -1: use all available CPUs.
         batchsize (int, optional): indicative number of rows to process per
             batch. A smaller batch size, possibly in combination with a
             smaller nb_parallel, will reduce the memory usage.
@@ -2482,7 +2482,8 @@ def union(
 
     """  # noqa: E501
     logger.info(
-        f"Start union: select from {input1_path} and {input2_path} to {output_path}"
+        f"union: start, with input1: {input1_path}, input2: {input2_path}, output: "
+        f"{output_path}"
     )
     return _geoops_sql.union(
         input1_path=Path(input1_path),

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -102,7 +102,8 @@ def apply(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"apply: start on {input_path}")
+    logger = logging.getLogger("geofileops.apply")
+    logger.info(f"Start on {input_path}")
 
     return _geoops_gpd.apply(
         input_path=Path(input_path),
@@ -289,8 +290,9 @@ def buffer(
     .. |buffer_mitre_10| image:: ../_static/images/buffer_mitre_10.png
         :alt: Buffer with mitre=1.0
     """  # noqa: E501
+    logger = logging.getLogger("geofileops.buffer")
     logger.info(
-        f"buffer: start, on {input_path} "
+        f"Start, on {input_path} "
         f"(distance: {distance}, quadrantsegments: {quadrantsegments})"
     )
 
@@ -374,7 +376,8 @@ def clip_by_geometry(
         force (bool, optional): overwrite existing output file(s).
             Defaults to False.
     """
-    logger.info(f"clip_by_geometry: start, on {input_path}")
+    logger = logging.getLogger("geofileops.clip_by_geometry")
+    logger.info(f"Start, on {input_path}")
     return _geoops_ogr.clip_by_geometry(
         input_path=Path(input_path),
         output_path=Path(output_path),
@@ -444,7 +447,8 @@ def convexhull(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"convexhull: start, on {input_path}")
+    logger = logging.getLogger("geofileops.convexhull")
+    logger.info(f"Start, on {input_path}")
 
     return _geoops_sql.convexhull(
         input_path=Path(input_path),
@@ -505,7 +509,8 @@ def delete_duplicate_geometries(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"delete_duplicate_geometries: start, on {input_path}")
+    logger = logging.getLogger("geofileops.delete_duplicate_geometries")
+    logger.info(f"Start, on {input_path}")
 
     return _geoops_sql.delete_duplicate_geometries(
         input_path=Path(input_path),
@@ -693,7 +698,8 @@ def dissolve(
             # If an empty list of geometry columns is passed, convert it to None
             groupby_columns = None
 
-    logger.info(f"dissolve: start, on {input_path} to {output_path}")
+    logger = logging.getLogger("geofileops.dissolve")
+    logger.info(f"Start, on {input_path} to {output_path}")
     return _geoops_gpd.dissolve(
         input_path=Path(input_path),
         output_path=Path(output_path),
@@ -745,7 +751,8 @@ def export_by_bounds(
         force (bool, optional): overwrite existing output file(s).
             Defaults to False.
     """
-    logger.info(f"export_by_bounds: start, on {input_path}")
+    logger = logging.getLogger("geofileops.export_by_bounds")
+    logger.info(f"Start, on {input_path}")
     return _geoops_ogr.export_by_bounds(
         input_path=Path(input_path),
         output_path=Path(output_path),
@@ -820,7 +827,8 @@ def isvalid(
         )
 
     # Go!
-    logger.info(f"isvalid: start, on {input_path}")
+    logger = logging.getLogger("geofileops.isvalid")
+    logger.info(f"Start, on {input_path}")
     return _geoops_sql.isvalid(
         input_path=Path(input_path),
         output_path=output_path,
@@ -906,7 +914,8 @@ def makevalid(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"makevalid: start, on {input_path}")
+    logger = logging.getLogger("geofileops.makevalid")
+    logger.info(f"Start, on {input_path}")
 
     if gridsize is None:
         gridsize = 0.0
@@ -985,7 +994,8 @@ def warp(
         force (bool, optional): overwrite existing output file(s).
             Defaults to False.
     """
-    logger.info(f"warp: start, on {input_path}")
+    logger = logging.getLogger("geofileops.warp")
+    logger.info(f"Start, on {input_path}")
     _geoops_ogr.warp(
         input_path=Path(input_path),
         output_path=Path(output_path),
@@ -1123,7 +1133,8 @@ def select(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"select: start, on {input_path}")
+    logger = logging.getLogger("geofileops.select")
+    logger.info(f"Start, on {input_path}")
 
     # Convert force_output_geometrytype to GeometryType (if necessary)
     if force_output_geometrytype is not None:
@@ -1218,7 +1229,8 @@ def simplify(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"simplify: start, on {input_path} with tolerance {tolerance}")
+    logger = logging.getLogger("geofileops.simplify")
+    logger.info(f"Start, on {input_path} with tolerance {tolerance}")
     if isinstance(algorithm, str):
         algorithm = SimplifyAlgorithm(algorithm)
 
@@ -1232,6 +1244,7 @@ def simplify(
             columns=columns,
             explodecollections=explodecollections,
             gridsize=gridsize,
+            keep_empty_geoms=keep_empty_geoms,
             where_post=where_post,
             nb_parallel=nb_parallel,
             batchsize=batchsize,
@@ -1249,6 +1262,7 @@ def simplify(
             columns=columns,
             explodecollections=explodecollections,
             gridsize=gridsize,
+            keep_empty_geoms=keep_empty_geoms,
             where_post=where_post,
             nb_parallel=nb_parallel,
             batchsize=batchsize,
@@ -1256,9 +1270,9 @@ def simplify(
         )
 
 
-################################################################################
+# ------------------------
 # Operations on two layers
-################################################################################
+# ------------------------
 
 
 def clip(
@@ -1340,7 +1354,8 @@ def clip(
     .. |clip_result| image:: ../_static/images/clip_result.png
         :alt: Clip result
     """  # noqa: E501
-    logger.info(f"clip: start on {input_path} with {clip_path} to {output_path}")
+    logger = logging.getLogger("geofileops.clip")
+    logger.info(f"Start on {input_path} with {clip_path} to {output_path}")
     return _geoops_sql.clip(
         input_path=Path(input_path),
         clip_path=Path(clip_path),
@@ -1426,7 +1441,8 @@ def erase(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"erase: start, on {input_path} with {erase_path} to {output_path}")
+    logger = logging.getLogger("geofileops.erase")
+    logger.info(f"Start, on {input_path} with {erase_path} to {output_path}")
     return _geoops_sql.erase(
         input_path=Path(input_path),
         erase_path=Path(erase_path),
@@ -1509,6 +1525,7 @@ def export_by_location(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
+    logger = logging.getLogger("geofileops.export_by_location")
     logger.info(
         f"export_by_location: select from {input_to_select_from_path} "
         f"interacting with {input_to_compare_with_path} to {output_path}"
@@ -1587,8 +1604,9 @@ def export_by_distance(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
+    logger = logging.getLogger("geofileops.export_by_distance")
     logger.info(
-        f"export_by_distance: select from {input_to_select_from_path} within "
+        f"select from {input_to_select_from_path} within "
         f"max_distance of {max_distance} from {input_to_compare_with_path} "
         f"to {output_path}"
     )
@@ -1683,9 +1701,8 @@ def identity(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(
-        f"identity: start, between {input1_path} and {input2_path} to {output_path}"
-    )
+    logger = logging.getLogger("geofileops.identity")
+    logger.info(f"Start, between {input1_path} and {input2_path} to {output_path}")
     return _geoops_sql.identity(
         input1_path=Path(input1_path),
         input2_path=Path(input2_path),
@@ -1735,9 +1752,8 @@ def split(
         FutureWarning,
         stacklevel=2,
     )
-    logger.info(
-        f"identity: start,  between {input1_path} and {input2_path} to {output_path}"
-    )
+    logger = logging.getLogger("geofileops.identity")
+    logger.info(f"Start,  between {input1_path} and {input2_path} to {output_path}")
     return _geoops_sql.identity(
         input1_path=Path(input1_path),
         input2_path=Path(input2_path),
@@ -1872,9 +1888,8 @@ def intersection(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(
-        f"intersection: start, between {input1_path} and {input2_path} to {output_path}"
-    )
+    logger = logging.getLogger("geofileops.intersection")
+    logger.info(f"Start, between {input1_path} and {input2_path} to {output_path}")
     return _geoops_sql.intersection(
         input1_path=Path(input1_path),
         input2_path=Path(input2_path),
@@ -1993,10 +2008,8 @@ def join_by_location(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(
-        f"join_by_location: select from {input1_path} joined with "
-        f"{input2_path} to {output_path}"
-    )
+    logger = logging.getLogger("geofileops.join_by_location")
+    logger.info(f"select from {input1_path} joined with {input2_path} to {output_path}")
     return _geoops_sql.join_by_location(
         input1_path=Path(input1_path),
         input2_path=Path(input2_path),
@@ -2073,10 +2086,8 @@ def join_nearest(
         force (bool, optional): overwrite existing output file(s).
             Defaults to False.
     """
-    logger.info(
-        f"join_nearest: select from {input1_path} joined with "
-        f"{input2_path} to {output_path}"
-    )
+    logger = logging.getLogger("geofileops.join_nearest")
+    logger.info(f"select from {input1_path} joined with {input2_path} to {output_path}")
     return _geoops_sql.join_nearest(
         input1_path=Path(input1_path),
         input2_path=Path(input2_path),
@@ -2282,10 +2293,8 @@ def select_two_layers(
         <a href="https://github.com/geofileops/geofileops/blob/main/geofileops/util/geofileops_sql.py" target="_blank">geofileops_sql.py</a>
 
     """  # noqa: E501
-    logger.info(
-        f"select_two_layers: select from {input1_path} and {input2_path} "
-        f"to {output_path}"
-    )
+    logger = logging.getLogger("geofileops.select_two_layers")
+    logger.info(f"select from {input1_path} and {input2_path} to {output_path}")
     return _geoops_sql.select_two_layers(
         input1_path=Path(input1_path),
         input2_path=Path(input2_path),
@@ -2384,8 +2393,9 @@ def symmetric_difference(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
+    logger = logging.getLogger("geofileops.symmetric_difference")
     logger.info(
-        f"symmetric_difference: start, with input1: {input1_path}, "
+        f"Start, with input1: {input1_path}, "
         f"input2 {input2_path}, output: {output_path}"
     )
     return _geoops_sql.symmetric_difference(
@@ -2483,8 +2493,9 @@ def union(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
+    logger = logging.getLogger("geofileops.union")
     logger.info(
-        f"union: start, with input1: {input1_path}, input2: {input2_path}, output: "
+        f"Start, with input1: {input1_path}, input2: {input2_path}, output: "
         f"{output_path}"
     )
     return _geoops_sql.union(

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -102,7 +102,7 @@ def apply(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"Start apply on {input_path}")
+    logger.info(f"apply: start on {input_path}")
 
     return _geoops_gpd.apply(
         input_path=Path(input_path),
@@ -290,7 +290,7 @@ def buffer(
         :alt: Buffer with mitre=1.0
     """  # noqa: E501
     logger.info(
-        f"Start buffer on {input_path} "
+        f"buffer: start, on {input_path} "
         f"(distance: {distance}, quadrantsegments: {quadrantsegments})"
     )
 
@@ -374,6 +374,7 @@ def clip_by_geometry(
         force (bool, optional): overwrite existing output file(s).
             Defaults to False.
     """
+    logger.info(f"clip_by_geometry: start, on {input_path}")
     return _geoops_ogr.clip_by_geometry(
         input_path=Path(input_path),
         output_path=Path(output_path),
@@ -443,7 +444,7 @@ def convexhull(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"Start convexhull on {input_path}")
+    logger.info(f"convexhull: start, on {input_path}")
 
     return _geoops_sql.convexhull(
         input_path=Path(input_path),
@@ -504,7 +505,7 @@ def delete_duplicate_geometries(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"Start delete_duplicate_geometries on {input_path}")
+    logger.info(f"delete_duplicate_geometries: start, on {input_path}")
 
     return _geoops_sql.delete_duplicate_geometries(
         input_path=Path(input_path),
@@ -692,7 +693,7 @@ def dissolve(
             # If an empty list of geometry columns is passed, convert it to None
             groupby_columns = None
 
-    logger.info(f"Start dissolve on {input_path} to {output_path}")
+    logger.info(f"dissolve: start, on {input_path} to {output_path}")
     return _geoops_gpd.dissolve(
         input_path=Path(input_path),
         output_path=Path(output_path),
@@ -744,6 +745,7 @@ def export_by_bounds(
         force (bool, optional): overwrite existing output file(s).
             Defaults to False.
     """
+    logger.info(f"export_by_bounds: start, on {input_path}")
     return _geoops_ogr.export_by_bounds(
         input_path=Path(input_path),
         output_path=Path(output_path),
@@ -818,7 +820,7 @@ def isvalid(
         )
 
     # Go!
-    logger.info(f"Start isvalid on {input_path}")
+    logger.info(f"isvalid: start, on {input_path}")
     return _geoops_sql.isvalid(
         input_path=Path(input_path),
         output_path=output_path,
@@ -904,7 +906,7 @@ def makevalid(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"Start makevalid on {input_path}")
+    logger.info(f"makevalid: start, on {input_path}")
 
     if gridsize is None:
         gridsize = 0.0
@@ -983,7 +985,7 @@ def warp(
         force (bool, optional): overwrite existing output file(s).
             Defaults to False.
     """
-    logger.info(f"Start warp on {input_path}")
+    logger.info(f"warp: start, on {input_path}")
     _geoops_ogr.warp(
         input_path=Path(input_path),
         output_path=Path(output_path),
@@ -1121,7 +1123,7 @@ def select(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"Start select on {input_path}")
+    logger.info(f"select: start, on {input_path}")
 
     # Convert force_output_geometrytype to GeometryType (if necessary)
     if force_output_geometrytype is not None:
@@ -1216,7 +1218,7 @@ def simplify(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"Start simplify on {input_path} with tolerance {tolerance}")
+    logger.info(f"simplify: start, on {input_path} with tolerance {tolerance}")
     if isinstance(algorithm, str):
         algorithm = SimplifyAlgorithm(algorithm)
 
@@ -1338,7 +1340,7 @@ def clip(
     .. |clip_result| image:: ../_static/images/clip_result.png
         :alt: Clip result
     """  # noqa: E501
-    logger.info(f"Start clip on {input_path} with {clip_path} to {output_path}")
+    logger.info(f"clip: start on {input_path} with {clip_path} to {output_path}")
     return _geoops_sql.clip(
         input_path=Path(input_path),
         clip_path=Path(clip_path),
@@ -1424,7 +1426,7 @@ def erase(
         <a href="https://www.gaia-gis.it/gaia-sins/spatialite-sql-latest.html" target="_blank">spatialite reference</a>
 
     """  # noqa: E501
-    logger.info(f"Start erase on {input_path} with {erase_path} to {output_path}")
+    logger.info(f"erase: start, on {input_path} with {erase_path} to {output_path}")
     return _geoops_sql.erase(
         input_path=Path(input_path),
         erase_path=Path(erase_path),
@@ -1508,7 +1510,7 @@ def export_by_location(
 
     """  # noqa: E501
     logger.info(
-        f"Start export_by_location: select from {input_to_select_from_path} "
+        f"export_by_location: select from {input_to_select_from_path} "
         f"interacting with {input_to_compare_with_path} to {output_path}"
     )
     return _geoops_sql.export_by_location(
@@ -1586,7 +1588,7 @@ def export_by_distance(
 
     """  # noqa: E501
     logger.info(
-        f"Start export_by_distance: select from {input_to_select_from_path} within "
+        f"export_by_distance: select from {input_to_select_from_path} within "
         f"max_distance of {max_distance} from {input_to_compare_with_path} "
         f"to {output_path}"
     )
@@ -1682,7 +1684,7 @@ def identity(
 
     """  # noqa: E501
     logger.info(
-        f"Start identity between {input1_path} and {input2_path} to {output_path}"
+        f"identity: start, between {input1_path} and {input2_path} to {output_path}"
     )
     return _geoops_sql.identity(
         input1_path=Path(input1_path),
@@ -1734,7 +1736,7 @@ def split(
         stacklevel=2,
     )
     logger.info(
-        f"Start identity between {input1_path} and {input2_path} to {output_path}"
+        f"identity: start,  between {input1_path} and {input2_path} to {output_path}"
     )
     return _geoops_sql.identity(
         input1_path=Path(input1_path),
@@ -1871,7 +1873,7 @@ def intersection(
 
     """  # noqa: E501
     logger.info(
-        f"Start intersection between {input1_path} and {input2_path} to {output_path}"
+        f"intersection: start, between {input1_path} and {input2_path} to {output_path}"
     )
     return _geoops_sql.intersection(
         input1_path=Path(input1_path),
@@ -1992,7 +1994,7 @@ def join_by_location(
 
     """  # noqa: E501
     logger.info(
-        f"Start join_by_location: select from {input1_path} joined with "
+        f"join_by_location: select from {input1_path} joined with "
         f"{input2_path} to {output_path}"
     )
     return _geoops_sql.join_by_location(
@@ -2072,7 +2074,7 @@ def join_nearest(
             Defaults to False.
     """
     logger.info(
-        f"Start join_nearest: select from {input1_path} joined with "
+        f"join_nearest: select from {input1_path} joined with "
         f"{input2_path} to {output_path}"
     )
     return _geoops_sql.join_nearest(
@@ -2281,7 +2283,7 @@ def select_two_layers(
 
     """  # noqa: E501
     logger.info(
-        f"Start select_two_layers: select from {input1_path} and {input2_path} "
+        f"select_two_layers: select from {input1_path} and {input2_path} "
         f"to {output_path}"
     )
     return _geoops_sql.select_two_layers(

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -642,6 +642,7 @@ def _apply_geooperation_to_layer(
     operation_name = operation_params.get("operation_name")
     if operation_name is None:
         operation_name = operation.value
+    log_prefix = f"{operation_name}: "
 
     # Check input parameters...
     if not input_path.exists():
@@ -652,7 +653,7 @@ def _apply_geooperation_to_layer(
         input_layer = gfo.get_only_layer(input_path)
     if output_path.exists():
         if force is False:
-            logger.info(f"{operation_name}: stop, output exists already {output_path}")
+            logger.info(f"{log_prefix}stop, output exists already {output_path}")
             return
         else:
             gfo.remove(output_path)
@@ -679,7 +680,7 @@ def _apply_geooperation_to_layer(
 
     # Prepare tmp files
     tmp_dir = _io_util.create_tempdir(f"geofileops/{operation.value}")
-    logger.debug(f"Start calculation to temp files in {tmp_dir}")
+    logger.debug(f"{log_prefix}Start calculation to temp files in {tmp_dir}")
 
     try:
         # Calculate the best number of parallel processes and batches for
@@ -695,7 +696,7 @@ def _apply_geooperation_to_layer(
         assert processing_params.batches is not None
 
         logger.info(
-            f"{operation_name}: start processing ({processing_params.nb_parallel} "
+            f"{log_prefix}start processing ({processing_params.nb_parallel} "
             f" parallel workers, batch size: {processing_params.batchsize})"
         )
         # Processing in threads is 2x faster for small datasets (on Windows)
@@ -815,12 +816,12 @@ def _apply_geooperation_to_layer(
             gfo.create_spatial_index(path=tmp_output_path, layer=output_layer)
             gfo.move(tmp_output_path, output_path)
         else:
-            logger.debug(f"{operation.value}: result was empty!")
+            logger.debug(f"{log_prefix}result was empty!")
 
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
-    logger.info(f"{operation_name}: ready, took {datetime.now()-start_time_global}!")
+    logger.info(f"{log_prefix}ready, took {datetime.now()-start_time_global}!")
 
 
 def _apply_geooperation(
@@ -981,6 +982,7 @@ def dissolve(
     # ----------------------------------
     start_time = datetime.now()
     operation = "dissolve"
+    log_prefix = f"{operation}: "
     result_info = {}
 
     # Check input parameters
@@ -1050,7 +1052,7 @@ def dissolve(
         if force is False:
             result_info[
                 "message"
-            ] = f"dissolve: output exists already {output_path} and force is false"
+            ] = f"{log_prefix}output exists already {output_path} and force is false"
             logger.info(result_info["message"])
             return result_info
         else:
@@ -1148,7 +1150,7 @@ def dissolve(
             prev_nb_batches = None
             last_pass = False
             pass_id = 0
-            logger.info(f"dissolve: start, input file {input_path}")
+            logger.info(f"{log_prefix}start, input file {input_path.name}")
             input_pass_layer: Optional[str] = input_layer
             while True:
                 # Get info of the current file that needs to be dissolved
@@ -1218,9 +1220,10 @@ def dissolve(
 
                 # Now go!
                 logger.info(
-                    f"dissolve: start pass {pass_id} to {len(tiles_gdf)} tiles "
+                    f"{log_prefix}start pass {pass_id} to {len(tiles_gdf)} tiles "
                     f"(batch size: {int(nb_rows_total/len(tiles_gdf))})"
                 )
+                pass_start = datetime.now()
                 _ = _dissolve_polygons_pass(
                     input_path=input_path,
                     output_notonborder_path=output_tmp_path,
@@ -1234,6 +1237,10 @@ def dissolve(
                     gridsize=gridsize,
                     keep_empty_geoms=False,
                     nb_parallel=nb_parallel,
+                )
+                logger.info(
+                    f"{log_prefix}pass {pass_id} ready, took "
+                    f"{datetime.now()-pass_start}"
                 )
 
                 # Prepare the next pass
@@ -1353,7 +1360,7 @@ def dissolve(
                 # All tiles are already dissolved to groups, but now the
                 # results from all tiles still need to be
                 # grouped/collected together.
-                logger.info("dissolve: finalize result")
+                logger.info(f"{log_prefix}finalize result")
                 if agg_columns is None:
                     # If there are no aggregation columns, things are not too
                     # complicated.
@@ -1478,9 +1485,7 @@ def dissolve(
         )
 
     # Return result info
-    result_info[
-        "message"
-    ] = f"dissolve: completely ready, took {datetime.now()-start_time}!"
+    result_info["message"] = f"{log_prefix}ready, took {datetime.now()-start_time}!"
     logger.info(result_info["message"])
     return result_info
 
@@ -1499,12 +1504,12 @@ def _dissolve_polygons_pass(
     keep_empty_geoms: bool,
     nb_parallel: int,
 ):
+    start_time = datetime.now()
+
     # Make sure the input file has a spatial index
     gfo.create_spatial_index(input_path, layer=input_layer, exist_ok=True)
 
     # Start calculation in parallel
-    start_time = datetime.now()
-    start_time = datetime.now()
     input_layerinfo = gfo.get_layerinfo(input_path, input_layer)
 
     # Processing in threads is 2x faster for small datasets (on Windows)
@@ -1632,8 +1637,6 @@ def _dissolve_polygons_pass(
                 start_time, nb_batches_done, nb_batches, "dissolve"
             )
 
-    logger.info(f"dissolve: pass ready, took {datetime.now()-start_time}!")
-
 
 def _dissolve_polygons(
     input_path: Path,
@@ -1723,7 +1726,7 @@ def _dissolve_polygons(
     perfinfo["time_read"] = (datetime.now() - start_read).total_seconds()
     return_info["nb_rows_done"] = len(input_gdf)
     if return_info["nb_rows_done"] == 0:
-        message = f"dissolve: no input geometries found in {input_path}"
+        message = f"dissolve_polygons: no input geometries found in {input_path}"
         logger.info(message)
         return_info["message"] = message
         return_info["total_time"] = (datetime.now() - start_time).total_seconds()
@@ -1879,7 +1882,7 @@ def _dissolve_polygons(
     perfinfo["time_to_file"] = (datetime.now() - start_to_file).total_seconds()
 
     # Finalise...
-    message = f"dissolve ready in {datetime.now()-start_time} on {input_path}!"
+    message = f"dissolve_polygons: ready in {datetime.now()-start_time} on {input_path}"
     logger.debug(message)
 
     # Collect perfinfo

--- a/geofileops/util/_geoops_ogr.py
+++ b/geofileops/util/_geoops_ogr.py
@@ -123,6 +123,7 @@ def _run_ogr(
     force: bool = False,
 ) -> bool:
     # Init
+    logger = logging.getLogger(f"geofileops.{operation}")
     start_time = datetime.now()
     if input_layer is None:
         input_layer = gfo.get_only_layer(input_path)
@@ -130,7 +131,7 @@ def _run_ogr(
         if force:
             gfo.remove(output_path)
         else:
-            logger.info(f"{operation}: stop, output exists already {output_path}")
+            logger.info(f"Stop, output exists already {output_path}")
             return True
 
     if input_layer is None:
@@ -162,5 +163,5 @@ def _run_ogr(
 
     # Run + return result
     result = _ogr_util.vector_translate_by_info(info)
-    logger.info(f"{operation}: ready, took {datetime.now()-start_time}!")
+    logger.info(f"Ready, took {datetime.now()-start_time}")
     return result

--- a/geofileops/util/_geoops_ogr.py
+++ b/geofileops/util/_geoops_ogr.py
@@ -9,15 +9,7 @@ from shapely import wkt
 import geofileops as gfo
 from geofileops.util import _ogr_util
 
-################################################################################
-# Some init
-################################################################################
-
 logger = logging.getLogger(__name__)
-
-################################################################################
-# Functions
-################################################################################
 
 
 def clip_by_geometry(
@@ -138,7 +130,7 @@ def _run_ogr(
         if force:
             gfo.remove(output_path)
         else:
-            logger.info(f"Stop {operation}: output exists already {output_path}")
+            logger.info(f"{operation}: stop, output exists already {output_path}")
             return True
 
     if input_layer is None:
@@ -170,5 +162,5 @@ def _run_ogr(
 
     # Run + return result
     result = _ogr_util.vector_translate_by_info(info)
-    logger.info(f"{operation} ready, took {datetime.now()-start_time}!")
+    logger.info(f"{operation}: ready, took {datetime.now()-start_time}!")
     return result

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -251,21 +251,22 @@ def isvalid(
             gfo.remove(output_path)
 
     # If output is sqlite based, check if all data can be read
+    logger = logging.getLogger("geofileops.isvalid")
     if validate_attribute_data:
         try:
             input_info = _geofileinfo.get_geofileinfo(input_path)
             if input_info.is_spatialite_based:
                 _sqlite_util.test_data_integrity(path=input_path)
-                logger.debug("isvalid: test_data_integrity was succesfull")
+                logger.debug("test_data_integrity was succesfull")
         except Exception:
             logger.exception(
-                f"isvalid: nb_invalid_geoms: {nb_invalid_geoms} + some attributes "
+                f"nb_invalid_geoms: {nb_invalid_geoms} + some attributes "
                 "could not be read!"
             )
             return False
 
     if nb_invalid_geoms > 0:
-        logger.info(f"isvalid: found {nb_invalid_geoms} invalid geoms in {output_path}")
+        logger.info(f"Found {nb_invalid_geoms} invalid geoms in {output_path}")
         return False
 
     # Nothing invalid found
@@ -290,8 +291,9 @@ def makevalid(
 ):
     # If output file exists already, either clean up or return...
     operation_name = "makevalid"
+    logger = logging.getLogger(f"geofileops.{operation_name}")
     if not force and output_path.exists():
-        logger.info(f"{operation_name}: stop, output exists already {output_path}")
+        logger.info(f"Stop, output exists already {output_path}")
         return
 
     # Init + prepare sql template for this operation
@@ -369,9 +371,10 @@ def select(
     force: bool = False,
 ):
     # Check if output exists already here, to avoid to much logging to be written
+    logger = logging.getLogger("geofileops.select")
     if output_path.exists():
         if force is False:
-            logger.info(f"select: stop, output exists already {output_path}")
+            logger.info(f"Stop, output exists already {output_path}")
             return
     logger.debug(f"  -> select to execute:\n{sql_stmt}")
 
@@ -381,7 +384,7 @@ def select(
             input_path, input_layer, raise_on_nogeom=False
         ).geometrytype
         logger.info(
-            "select: no force_output_geometrytype specified, so defaults to input "
+            "No force_output_geometrytype specified, so defaults to input "
             f"layer geometrytype: {force_output_geometrytype}"
         )
 
@@ -1597,8 +1600,9 @@ def join_nearest(
     # Init some things...
     # Because there is preprocessing done in this function, check output path
     # here already
+    logger = logging.getLogger("geofileops.join_nearest")
     if output_path.exists() and force is False:
-        logger.info(f"join_nearest: stop, output exists already {output_path}")
+        logger.info(f"Stop, output exists already {output_path}")
         return
     if input1_layer is None:
         input1_layer = gfo.get_only_layer(input1_path)

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -261,7 +261,7 @@ def isvalid(
             input_info = _geofileinfo.get_geofileinfo(input_path)
             if input_info.is_spatialite_based:
                 _sqlite_util.test_data_integrity(path=input_path)
-                logger.debug("test_data_integrity was succesfull")
+                logger.debug("isvalid: test_data_integrity was succesfull")
         except Exception:
             logger.exception(
                 f"nb_invalid_geoms: {nb_invalid_geoms} + some attributes could not be "
@@ -270,7 +270,7 @@ def isvalid(
             return False
 
     if nb_invalid_geoms > 0:
-        logger.info(f"Found {nb_invalid_geoms} invalid geoms in {output_path}")
+        logger.info(f"isvalid: found {nb_invalid_geoms} invalid geoms in {output_path}")
         return False
 
     # Nothing invalid found
@@ -296,7 +296,7 @@ def makevalid(
     # If output file exists already, either clean up or return...
     operation_name = "makevalid"
     if not force and output_path.exists():
-        logger.info(f"Stop {operation_name}: output exists already {output_path}")
+        logger.info(f"{operation_name}: stop, output exists already {output_path}")
         return
 
     # Init + prepare sql template for this operation
@@ -376,7 +376,7 @@ def select(
     # Check if output exists already here, to avoid to much logging to be written
     if output_path.exists():
         if force is False:
-            logger.info(f"Stop select: output exists already {output_path}")
+            logger.info(f"select: stop, output exists already {output_path}")
             return
     logger.debug(f"  -> select to execute:\n{sql_stmt}")
 
@@ -386,8 +386,8 @@ def select(
             input_path, input_layer, raise_on_nogeom=False
         ).geometrytype
         logger.info(
-            "No force_output_geometrytype specified, so defaults to input layer "
-            f"geometrytype: {force_output_geometrytype}"
+            "select: no force_output_geometrytype specified, so defaults to input "
+            f"layer geometrytype: {force_output_geometrytype}"
         )
 
     # Go!
@@ -530,7 +530,7 @@ def _single_layer_vector_operation(
     # If output file exists already, either clean up or return...
     if output_path.exists():
         if force is False:
-            logger.info(f"Stop {operation_name}: output exists already {output_path}")
+            logger.info(f"{operation_name}: stop, output exists already {output_path}")
             return
         else:
             gfo.remove(output_path)
@@ -700,8 +700,8 @@ def _single_layer_vector_operation(
         )
 
         logger.info(
-            f"Start {operation_name} ({processing_params.nb_parallel} parallel workers,"
-            f" batch size: {processing_params.batchsize})"
+            f"{operation_name}: start processing ({processing_params.nb_parallel} "
+            f"parallel workers, batch size: {processing_params.batchsize})"
         )
 
         # Prepare temp output filename
@@ -844,13 +844,13 @@ def _single_layer_vector_operation(
                 tmp_output_path.with_suffix(".dbf"), output_path.with_suffix(".dbf")
             )
         else:
-            logger.debug(f"Result of {operation_name} was empty!")
+            logger.debug(f"{operation_name}: result was empty!")
 
     finally:
         # Clean tmp dir
         shutil.rmtree(tempdir, ignore_errors=True)
 
-    logger.info(f"Processing ready, took {datetime.now()-start_time}!")
+    logger.info(f"{operation_name}: ready, took {datetime.now()-start_time}!")
 
 
 ################################################################################
@@ -1601,7 +1601,7 @@ def join_nearest(
     # Because there is preprocessing done in this function, check output path
     # here already
     if output_path.exists() and force is False:
-        logger.info(f"Stop join_nearest: output exists already {output_path}")
+        logger.info(f"join_nearest: stop, output exists already {output_path}")
         return
     if input1_layer is None:
         input1_layer = gfo.get_only_layer(input1_path)
@@ -2095,7 +2095,7 @@ def union(
     finally:
         shutil.rmtree(tempdir, ignore_errors=True)
 
-    logger.info(f"union ready, took {datetime.now()-start_time}!")
+    logger.info(f"union: ready, took {datetime.now()-start_time}!")
 
 
 def _two_layer_vector_operation(
@@ -2190,7 +2190,7 @@ def _two_layer_vector_operation(
         )
     if output_path.exists():
         if force is False:
-            logger.info(f"Stop {operation_name}: output exists already {output_path}")
+            logger.info(f"{operation_name}: stop, output exists already {output_path}")
             return
         else:
             gfo.remove(output_path)
@@ -2216,9 +2216,7 @@ def _two_layer_vector_operation(
     try:
         # Prepare tmp files/batches
         # -------------------------
-        logger.info(
-            f"Prepare input (params) for {operation_name} with tempdir: {tempdir}"
-        )
+        logger.debug(f"{operation_name}: Prepare input (params), tempdir: {tempdir}")
         processing_params = _prepare_processing_params(
             input1_path=input1_path,
             input1_layer=input1_layer,
@@ -2390,8 +2388,8 @@ def _two_layer_vector_operation(
             True if input1_tmp_layerinfo.featurecount <= 100 else False
         )
         logger.info(
-            f"Start {operation_name} ({processing_params.nb_parallel} parallel workers,"
-            f" batch size: {processing_params.batchsize})"
+            f"{operation_name}: start processing ({processing_params.nb_parallel} "
+            f"parallel workers, batch size: {processing_params.batchsize})"
         )
         with _processing_util.PooledExecutorFactory(
             threadpool=calculate_in_threads,
@@ -2528,9 +2526,9 @@ def _two_layer_vector_operation(
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 gfo.move(tmp_output_path, output_path)
         else:
-            logger.debug(f"Result of {operation_name} was empty!")
+            logger.debug(f"{operation_name}: result was empty!")
 
-        logger.info(f"{operation_name} ready, took {datetime.now()-start_time}!")
+        logger.info(f"{operation_name}: ready, took {datetime.now()-start_time}!")
     except Exception:
         gfo.remove(output_path, missing_ok=True)
         gfo.remove(tmp_output_path, missing_ok=True)
@@ -3061,7 +3059,7 @@ def dissolve_singlethread(
     # Check output path
     if output_path.exists():
         if force is False:
-            logger.info(f"Stop dissolve: Output exists already {output_path}")
+            logger.info(f"dissolve: stop, output exists already {output_path}")
             return
         else:
             gfo.remove(output_path)
@@ -3189,4 +3187,4 @@ def dissolve_singlethread(
     finally:
         shutil.rmtree(tempdir, ignore_errors=True)
 
-    logger.info(f"Processing ready, took {datetime.now()-start_time}!")
+    logger.info(f"dissolve: ready, took {datetime.now()-start_time}!")


### PR DESCRIPTION
- a sensible logger name makes logging a lot more consistent and readable, current approach was redundent with `%(pathname)`
- added explicit logging for the steps in multi-step operations like `union` and `symmetric_difference`.

