### PR TITLE
Speedup identity and union for some files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
   applying on-the-fly subdividing of complex geometries to speed up processing. The new
   parameter `subdivide_coords` can be used to control the feature. For files with very
   large input geometries, up to 100x faster + 10x less memory usage.
-  (#329, #330, #331, #357, #396)
+  (#329, #330, #331, #357, #396, #427)
 - Improve performance of spatial operations when only one batch is used (#271)
 - Improve performance of single layer operations (#375)
 - Improve performance of some geopandas/shapely based operations (#342, #408)

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -1857,8 +1857,6 @@ def identity(
             gfo.create_spatial_index(path=tmp_output_path, layer=output_layer)
 
         # Now we are ready to move the result to the final spot...
-        if output_path.exists():
-            gfo.remove(output_path)
         gfo.move(tmp_output_path, output_path)
 
     finally:
@@ -2123,8 +2121,6 @@ def union(
             gfo.create_spatial_index(path=tmp_output_path, layer=output_layer)
 
         # Now we are ready to move the result to the final spot...
-        if output_path.exists():
-            gfo.remove(output_path)
         gfo.move(tmp_output_path, output_path)
 
     finally:

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -347,6 +347,32 @@ def test_identity(tmp_path, suffix, epsg, gridsize):
     )
 
 
+def test_identity_force(tmp_path):
+    # Prepare test data
+    input1_path = test_helper.get_testfile("polygon-parcel")
+    input2_path = test_helper.get_testfile("polygon-zone")
+    output_path = tmp_path / f"output{input1_path.suffix}"
+    output_path.touch()
+
+    # Test with force False (the default): existing output file should stay the same
+    mtime_orig = output_path.stat().st_mtime
+    gfo.identity(
+        input1_path=input1_path,
+        input2_path=input2_path,
+        output_path=output_path,
+    )
+    assert output_path.stat().st_mtime == mtime_orig
+
+    # With force=True
+    gfo.identity(
+        input1_path=input1_path,
+        input2_path=input2_path,
+        output_path=output_path,
+        force=True,
+    )
+    assert output_path.stat().st_mtime != mtime_orig
+
+
 @pytest.mark.parametrize("testfile", ["polygon-parcel"])
 @pytest.mark.parametrize(
     "suffix, epsg, gridsize, explodecollections, nb_parallel",
@@ -1591,3 +1617,29 @@ def test_union_circles(tmp_path, suffix, epsg):
         check_less_precise=True,
         normalize=True,
     )
+
+
+def test_union_force(tmp_path):
+    # Prepare test data
+    input1_path = test_helper.get_testfile("polygon-parcel")
+    input2_path = test_helper.get_testfile("polygon-zone")
+    output_path = tmp_path / f"output{input1_path.suffix}"
+    output_path.touch()
+
+    # Test with force False (the default): existing output file should stay the same
+    mtime_orig = output_path.stat().st_mtime
+    gfo.union(
+        input1_path=input1_path,
+        input2_path=input2_path,
+        output_path=output_path,
+    )
+    assert output_path.stat().st_mtime == mtime_orig
+
+    # With force=True
+    gfo.union(
+        input1_path=input1_path,
+        input2_path=input2_path,
+        output_path=output_path,
+        force=True,
+    )
+    assert output_path.stat().st_mtime != mtime_orig


### PR DESCRIPTION
In some cases identity (and so also union, as it used identity under the hood), is very slow. Not sure what the exact trigger is, but in this case the identity was calculated between two largish input files (2 files of +- 3 GB). Previous test cases focused rather on one big file and one smaller.

This PR introduces 2 changes to solve this:
- the seperate intermediate operations, `intersection` and `erase`, executed seperately took only 50% of the time. This PR changes identity and union so the `intersection` and `erase` are calculated seperately and appended afterwards instead of combining them in one sql query.
- add ST_Intersects filter in the correclated subquery getting the neighbours to erase them. In previous tests the ST_Intersects filter being there or not didn't give a difference, so it was removed. For this new test case this gives a 10x speed improvement.