### PR TITLE
Fix to erase speedup introduced in #433

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
   applying on-the-fly subdividing of complex geometries to speed up processing. The new
   parameter `subdivide_coords` can be used to control the feature. For files with very
   large input geometries, up to 100x faster + 10x less memory usage.
-  (#329, #330, #331, #357, #396, #427, #433)
+  (#329, #330, #331, #357, #396, #427, #438)
 - Improve performance of spatial operations when only one batch is used (#271)
 - Improve performance of single layer operations (#375)
 - Improve performance of some geopandas/shapely based operations (#342, #408)


### PR DESCRIPTION
In #433 a speedup was introduced using spatialite function ST_Subdivide, but while performance testing using large files it became clear the function is flawed: it returns incorrect results in some cases leading to wrong erases. The issue is reported here: https://groups.google.com/g/spatialite-users/c/Pve3dbJj5Ug

This PR replaces this by a pure python implementation, which seems the only working option. in some of the earlier commits in this PR some alternative options are included, but they were all flawed in some way as documented in those commits.