### PR TITLE
Fix dissolve error when pass that isn't last one has 0 polygons in onborder result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Bugs fixed
 
-- Fix error in erase if erase_path countains multiple layers (#451)
+- Fix error in `erase` if `erase_path` countains multiple layers (#451)
+- Fix error in `dissolve` if a pass that is not the last one doesn't have any onborder 
+  polygons in its result (#)
 
 ## 0.8.0 (2023-11-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Bugs fixed
 
 - Fix error in `erase` if `erase_path` countains multiple layers (#451)
-- Fix error in `dissolve` if a pass that is not the last one doesn't have any onborder 
-  polygons in its result (#459)
+- Fix error in `dissolve` on polygon input if a pass that is not the last one has 0 
+  onborder polygons in its result (#459)
 
 ## 0.8.0 (2023-11-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fix error in `erase` if `erase_path` countains multiple layers (#451)
 - Fix error in `dissolve` if a pass that is not the last one doesn't have any onborder 
-  polygons in its result (#)
+  polygons in its result (#459)
 
 ## 0.8.0 (2023-11-24)
 


### PR DESCRIPTION
In this case an error `input_path doesn't exist: output_xxxx_onborder.gpkg` was raised.