### PR TITLE
Fix groupby parameter of dissolve becoming case sensitive when agg_columns is also specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Fix error in `erase` if `erase_path` countains multiple layers (#451)
 - Fix error in `dissolve` on polygon input if a pass that is not the last one has 0 
   onborder polygons in its result (#459, #461)
+- Fix `groupby` parameter becoming case sensitive in `dissolve` when `agg_columns` is
+  also specified (#462)
 
 ## 0.8.0 (2023-11-24)
 

--- a/geofileops/util/_general_util.py
+++ b/geofileops/util/_general_util.py
@@ -42,17 +42,20 @@ def align_casing(string_to_align: str, strings_to_align_to: Iterable) -> str:
 
 
 def align_casing_list(
-    strings_to_align: List[str], strings_to_align_to: Iterable
+    strings_to_align: List[str],
+    strings_to_align_to: Iterable,
+    raise_on_missing: bool = True,
 ) -> List[str]:
     """
     Search the string caseintensitive in a list of strings.
-
-    If a string is not found in strings_to_align_to, a ValueError is thrown.
 
     Args:
         strings_to_align (List[str]): strings to align the casing of to
             strings_to_align_to.
         strings_to_align_to (Iterable): strings to align the casing with.
+        raise_on_missing (bool, optional): if True, a ValueError is raised if a string
+            in ``strings_to_align`` is not found in ``strings_to_align_to``. If False,
+            the casing in ``strings_to_align`` is retained in the output.
 
     Raises:
         ValueError: a string in strings_to_align was nog found in strings_to_align_to.
@@ -68,8 +71,11 @@ def align_casing_list(
         string_aligned = strings_to_align_to_upper_dict.get(string.upper())
         if string_aligned is not None:
             strings_aligned.append(string_aligned)
-        else:
+        elif raise_on_missing:
             raise ValueError(f"{string} not available in: {strings_to_align_to}")
+        else:
+            strings_aligned.append(string)
+
     return strings_aligned
 
 

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -1064,15 +1064,17 @@ def dissolve(
         output_layer = gfo.get_default_layer(output_path)
 
     # Check columns in groupby_columns
+    columns_available = list(input_layerinfo.columns) + ["fid"]
     if groupby_columns is not None:
-        columns_in_layer_upper = [
-            column.upper() for column in list(input_layerinfo.columns) + ["fid"]
-        ]
+        columns_in_layer_upper = [column.upper() for column in columns_available]
         for column in groupby_columns:
             if column.upper() not in columns_in_layer_upper:
                 raise ValueError(
                     f"column in groupby_columns not available in layer: {column}"
                 )
+        columns_available = _general_util.align_casing_list(
+            columns_available, groupby_columns, raise_on_missing=False
+        )
 
     # Check agg_columns param
     if agg_columns is not None:
@@ -1086,19 +1088,19 @@ def dissolve(
         if "json" in agg_columns:
             if agg_columns["json"] is None:
                 agg_columns["json"] = [
-                    col for col in input_layerinfo.columns if col.upper() != "INDEX"
+                    c for c in columns_available if c.lower() not in ("index", "fid")
                 ]
             else:
                 # Align casing of column names to data
                 agg_columns["json"] = _general_util.align_casing_list(
-                    agg_columns["json"], list(input_layerinfo.columns) + ["fid"]
+                    agg_columns["json"], columns_available
                 )
         elif "columns" in agg_columns:
             # Loop through all rows
             for agg_column in agg_columns["columns"]:
                 # Check if column exists + set casing same as in data
                 agg_column["column"] = _general_util.align_casing(
-                    agg_column["column"], list(input_layerinfo.columns) + ["fid"]
+                    agg_column["column"], columns_available
                 )
 
     # Now input parameters are checked, check if we need to calculate anyway

--- a/tests/test_geofileops_singlelayer_gpd.py
+++ b/tests/test_geofileops_singlelayer_gpd.py
@@ -1021,7 +1021,7 @@ def test_dissolve_polygons_aggcolumns_columns(tmp_path, suffix):
     assert output_gdf["geometry"][0] is not None
 
     # Check agg_columns results
-    grasland_idx = output_gdf[output_gdf["GEWASGROEP"] == "Grasland"].index.to_list()[0]
+    grasland_idx = output_gdf[output_gdf["GEWASgroep"] == "Grasland"].index.to_list()[0]
     assert output_gdf["lbl_max"][grasland_idx] == "Grasland"
     assert output_gdf["gwsgrp_cnt"][grasland_idx] == 30
     assert output_gdf["lbl_count"][grasland_idx] == 30
@@ -1035,7 +1035,7 @@ def test_dissolve_polygons_aggcolumns_columns(tmp_path, suffix):
     assert output_gdf["tlt_sum"][grasland_idx] == 1800
 
     groenten_idx = output_gdf[
-        output_gdf["GEWASGROEP"] == "Groenten, kruiden en sierplanten"
+        output_gdf["GEWASgroep"] == "Groenten, kruiden en sierplanten"
     ].index.to_list()[0]
     assert output_gdf["lbl_count"][groenten_idx] == 5
     print(
@@ -1070,7 +1070,7 @@ def test_dissolve_polygons_aggcolumns_json(tmp_path, agg_columns):
     gfo.dissolve(
         input_path=input_path,
         output_path=output_path,
-        groupby_columns=["GEWASGROEP"],
+        groupby_columns=["GEWASgroep"],
         agg_columns=agg_columns,
         explodecollections=False,
         nb_parallel=2,

--- a/tests/test_geofileops_singlelayer_gpd.py
+++ b/tests/test_geofileops_singlelayer_gpd.py
@@ -361,7 +361,7 @@ def test_dissolve_linestrings_groupby(tmp_path, suffix, epsg):
         output_basepath.parent
         / f"{output_basepath.stem}_groupby_noexpl{output_basepath.suffix}"
     )
-    groupby_columns = ["NISCODE"]
+    groupby_columns = ["NiScoDe"]
     gfo.dissolve(
         input_path=input_path,
         output_path=output_path,
@@ -525,7 +525,7 @@ def test_dissolve_linestrings_aggcolumns_json(tmp_path, agg_columns):
     "suffix, epsg, explode_input, groupby_columns, explode, gridsize, where_post, "
     "expected_featurecount",
     [
-        (".gpkg", 31370, False, ["GEWASGROEP"], True, 0.0, "", 25),
+        (".gpkg", 31370, False, ["GEWASgroep"], True, 0.0, "", 25),
         (".gpkg", 31370, False, ["GEWASGROEP"], False, 0.0, "", 6),
         (".gpkg", 31370, True, ["GEWASGROEP"], False, 0.0, "", 6),
         (".gpkg", 31370, False, ["gewasGROEP"], False, 0.01, WHERE_AREA_GT_5000, 4),
@@ -944,9 +944,9 @@ def test_dissolve_polygons_aggcolumns_columns(tmp_path, suffix):
     #       unique values, to be a better test case!
     agg_columns = {
         "columns": [
-            {"column": "lblhfdtlt", "agg": "max", "as": "lbl_max"},
+            {"column": "lblHFDtlt", "agg": "max", "as": "lbl_max"},
             {"column": "GEWASGROEP", "agg": "count", "as": "gwsgrp_cnt"},
-            {"column": "lblhfdtlt", "agg": "count", "as": "lbl_count"},
+            {"column": "lblhfdTLT", "agg": "count", "as": "lbl_count"},
             {
                 "column": "lblhfdtlt",
                 "agg": "count",
@@ -972,7 +972,7 @@ def test_dissolve_polygons_aggcolumns_columns(tmp_path, suffix):
             {"column": "fid", "agg": "concat", "as": "fid_concat"},
         ]
     }
-    groupby_columns = ["GEWASGROEP"]
+    groupby_columns = ["GEWASgroep"]
     gfo.dissolve(
         input_path=input_path,
         output_path=output_path,


### PR DESCRIPTION
Normally the `groupby` parameter of `dissolve` is case insenitive like other `column` parameters, but it became case sensitive when agg columns was specified.

Fixed.

resolves #457