### PR TITLE
BUG: Fix error in two layer operations if equal column aliases used based on constant/function result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Fix `dissolve` possibly having EMPTY geometries as output if `gridsize <> 0.0` (#473)
 - Fix wrong results from `join_by_location` if ran on result of `join_by_location`
   with `column_prefixes=""` (#475)
+- Fix error in two layer operations if equal column aliases used based on a constant or
+  a function result (#477)
 
 ## 0.8.1 (2024-01-13)
 

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -1545,7 +1545,7 @@ def join_by_location(
                         ,ST_relate(
                             layer1.{{input1_geometrycolumn}},
                             layer2.{{input2_geometrycolumn}}
-                         ) AS GFO_$TEMP$_SPATIAL_RELATION
+                         ) AS "GFO_$TEMP$_SPATIAL_RELATION"
                     FROM {{input1_databasename}}."{{input1_layer}}" layer1
                     JOIN {{input1_databasename}}."{input1_layer_rtree}" layer1tree
                       ON layer1.fid = layer1tree.id
@@ -1561,7 +1561,7 @@ def join_by_location(
                    LIMIT -1 OFFSET 0
                   ) sub_filter
                WHERE {spatial_relations_filter.format(
-                    spatial_relation="sub_filter.GFO_$TEMP$_SPATIAL_RELATION")}
+                    spatial_relation='sub_filter."GFO_$TEMP$_SPATIAL_RELATION"')}
                LIMIT -1 OFFSET 0
               ) sub_area
            {area_inters_filter}
@@ -1569,7 +1569,7 @@ def join_by_location(
         SELECT sub.geom
               {{layer1_columns_from_subselect_str}}
               {{layer2_columns_from_subselect_str}}
-              ,sub.GFO_$TEMP$_SPATIAL_RELATION AS spatial_relation
+              ,sub."GFO_$TEMP$_SPATIAL_RELATION" AS spatial_relation
               {area_inters_column_in_output}
           FROM layer1_relations_filtered sub
     """

--- a/geofileops/util/_sqlite_util.py
+++ b/geofileops/util/_sqlite_util.py
@@ -236,7 +236,7 @@ def get_columns(
                 # If PRAGMA TABLE_INFO doesn't specify the datatype, determine based
                 # on data.
                 if columntype is None or columntype == "":
-                    sql = f"SELECT typeof({columnname}) FROM tmp;"
+                    sql = f'SELECT typeof("{columnname}") FROM tmp;'
                     result = conn.execute(sql).fetchall()
                     if len(result) > 0 and result[0][0] is not None:
                         columns[columnname] = result[0][0]

--- a/geofileops/util/_sqlite_util.py
+++ b/geofileops/util/_sqlite_util.py
@@ -225,7 +225,7 @@ def get_columns(
                 # Use ST_GeometryType to get the type
                 # based on the data + apply to_multitype to be sure
                 if output_geometrytype is None:
-                    sql = f"SELECT ST_GeometryType({columnname}) FROM tmp;"
+                    sql = f'SELECT ST_GeometryType("{columnname}") FROM tmp;'
                     result = conn.execute(sql).fetchall()
                     if len(result) > 0 and result[0][0] is not None:
                         output_geometrytype = GeometryType[result[0][0]].to_multitype

--- a/tests/test_sqlite_util.py
+++ b/tests/test_sqlite_util.py
@@ -136,8 +136,10 @@ def test_get_columns():
 
     input1_info = gfo.get_layerinfo(input1_path)
     input2_info = gfo.get_layerinfo(input2_path)
+    # Also include an identical column name aliasing a constant, is special case that
+    # was a bug (https://github.com/geofileops/geofileops/pull/477).
     sql_stmt = f"""
-        SELECT layer1.OIDN, layer1.UIDN, layer1.datum, layer2.naam
+        SELECT layer1.OIDN, layer1.UIDN, layer1.datum, layer2.naam, 'test' AS naam
           FROM {{input1_databasename}}."{input1_info.name}" layer1
           CROSS JOIN {{input2_databasename}}."{input2_info.name}" layer2
          WHERE 1=1
@@ -152,7 +154,7 @@ def test_get_columns():
         sql_stmt=sql_stmt, input1_path=input1_path, input2_path=input2_path
     )
 
-    assert len(columns) == 4
+    assert len(columns) == 5
 
 
 def test_create_table_as_sql_single_input(tmp_path):


### PR DESCRIPTION
E.g. `SELECT layer2.naam, 'test' AS naam ... ` raised error `sqlite3.OperationalError: near ":1": syntax error`

Also related to #475, where this could occur for column `spatial_relation`.