### PR TITLE
BUG: Fix `erase` and depending operations if `subdivide_coords` < 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   with `column_prefixes=""` (#475)
 - Fix error in two layer operations if equal column aliases used based on a constant or
   a function result (#477)
+- Fix `erase` if `subdivide_coords` < 1 (#489)
 
 ## 0.8.1 (2024-01-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
   with `column_prefixes=""` (#475)
 - Fix error in two layer operations if equal column aliases used based on a constant or
   a function result (#477)
-- Fix `erase` if `subdivide_coords` < 1 (#489)
+- Fix `erase` (and depending two layer operations like `union`,...) giving wrong results
+  if `subdivide_coords` < 1 (#489)
 
 ## 0.8.1 (2024-01-13)
 

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -1827,7 +1827,7 @@ def erase(
         subdivide_coords (int, optional): the input geometries will be subdivided to
             parts with about ``subdivide_coords`` coordinates during processing which
             can offer a large speed up for complex geometries. Subdividing can result in
-            extra collinear points being added to the boundaries of the output. If < 0,
+            extra collinear points being added to the boundaries of the output. If 0,
             no subdividing is applied. Defaults to 2000.
         force (bool, optional): overwrite existing output file(s).
             Defaults to False.

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -1827,8 +1827,8 @@ def erase(
         subdivide_coords (int, optional): the input geometries will be subdivided to
             parts with about ``subdivide_coords`` coordinates during processing which
             can offer a large speed up for complex geometries. Subdividing can result in
-            extra collinear points being added to the boundaries of the output. If 0,
-            no subdividing is applied. Defaults to 2000.
+            extra collinear points being added to the boundaries of the output. If 0, no
+            subdividing is applied. Defaults to 2000.
         force (bool, optional): overwrite existing output file(s).
             Defaults to False.
 
@@ -2107,8 +2107,8 @@ def identity(
         subdivide_coords (int, optional): the input geometries will be subdivided to
             parts with about ``subdivide_coords`` coordinates during processing which
             can offer a large speed up for complex geometries. Subdividing can result in
-            extra collinear points being added to the boundaries of the output. If < 0,
-            no subdividing is applied. Defaults to 2000.
+            extra collinear points being added to the boundaries of the output. If 0, no
+            subdividing is applied. Defaults to 2000.
         force (bool, optional): overwrite existing output file(s).
             Defaults to False.
 
@@ -2899,8 +2899,8 @@ def symmetric_difference(
         subdivide_coords (int, optional): the input geometries will be subdivided to
             parts with about ``subdivide_coords`` coordinates during processing which
             can offer a large speed up for complex geometries. Subdividing can result in
-            extra collinear points being added to the boundaries of the output. If < 0,
-            no subdividing is applied. Defaults to 2000.
+            extra collinear points being added to the boundaries of the output. If 0, no
+            subdividing is applied. Defaults to 2000.
         force (bool, optional): overwrite existing output file(s).
             Defaults to False.
 
@@ -3028,8 +3028,8 @@ def union(
         subdivide_coords (int, optional): the input geometries will be subdivided to
             parts with about ``subdivide_coords`` coordinates during processing which
             can offer a large speed up for complex geometries. Subdividing can result in
-            extra collinear points being added to the boundaries of the output. If < 0,
-            no subdividing is applied. Defaults to 2000.
+            extra collinear points being added to the boundaries of the output. If 0, no
+            subdividing is applied. Defaults to 2000.
         force (bool, optional): overwrite existing output file(s).
             Defaults to False.
 

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -994,6 +994,10 @@ def erase(
     output_with_spatial_index: bool = True,
     operation_prefix: str = "",
 ):
+    # Check input params
+    if subdivide_coords < 0:
+        raise ValueError("subdivide_coords < 0 is not allowed")
+
     # Because there might be extra preparation of the erase layer before going ahead
     # with the real calculation, do some additional init + checks here...
     operation = f"{operation_prefix}erase"
@@ -1130,8 +1134,9 @@ def erase(
         SELECT * FROM (
           SELECT IFNULL(
                    ( SELECT IFNULL(
-                               IIF(ST_NPoints(layer1.{{input1_geometrycolumn}})
-                                        < {subdivide_coords},
+                               IIF({subdivide_coords} <= 0
+                                      OR ST_NPoints(layer1.{{input1_geometrycolumn}})
+                                             < {subdivide_coords},
                                    IIF(ST_Union(layer2_sub.{{input2_geometrycolumn}})
                                             IS NULL,
                                        layer1.{{input1_geometrycolumn}},

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -994,12 +994,11 @@ def erase(
     output_with_spatial_index: bool = True,
     operation_prefix: str = "",
 ):
-    # Check input params
+    # Because there might be extra preparation of the erase layer before going ahead
+    # with the real calculation, do some additional init + checks here...
     if subdivide_coords < 0:
         raise ValueError("subdivide_coords < 0 is not allowed")
 
-    # Because there might be extra preparation of the erase layer before going ahead
-    # with the real calculation, do some additional init + checks here...
     operation = f"{operation_prefix}erase"
     logger = logging.getLogger(f"geofileops.{operation}")
 
@@ -1936,6 +1935,8 @@ def identity(
 
     # Because the calculations of the intermediate results will be towards temp files,
     # we need to do some additional init + checks here...
+    if subdivide_coords < 0:
+        raise ValueError("subdivide_coords < 0 is not allowed")
     logger = logging.getLogger("geofileops.identity")
     if output_path.exists():
         if force is False:
@@ -2054,6 +2055,8 @@ def symmetric_difference(
 
     # Because both erase calculations will be towards temp files,
     # we need to do some additional init + checks here...
+    if subdivide_coords < 0:
+        raise ValueError("subdivide_coords < 0 is not allowed")
     if force is False and output_path.exists():
         return
     if output_layer is None:
@@ -2184,6 +2187,9 @@ def union(
 
     # Because the calculations of the intermediate results will be towards temp files,
     # we need to do some additional init + checks here...
+    if subdivide_coords < 0:
+        raise ValueError("subdivide_coords < 0 is not allowed")
+
     logger = logging.getLogger("geofileops.union")
 
     if output_path.exists():

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -232,6 +232,25 @@ def test_erase_force(tmp_path):
     assert output_path.stat().st_mtime != mtime_orig
 
 
+@pytest.mark.parametrize(
+    "kwargs, expected_error",
+    [
+        ({"erase_path": None}, "erase_layer must be None if erase_path is None"),
+        ({"subdivide_coords": -1}, "subdivide_coords < 0 is not allowed"),
+    ],
+)
+def test_erase_invalid_params(kwargs, expected_error):
+    if "erase_path" not in kwargs:
+        kwargs["erase_path"] = "erase.gpkg"
+    with pytest.raises(ValueError, match=expected_error):
+        gfo.erase(
+            input_path="input.gpkg",
+            output_path="output.gpkg",
+            erase_layer="invalid",
+            **kwargs,
+        )
+
+
 @pytest.mark.parametrize("subdivide_coords", [2000, 5])
 def test_erase_self(tmp_path, subdivide_coords):
     input_path = test_helper.get_testfile("polygon-overlappingcircles-all")
@@ -255,25 +274,6 @@ def test_erase_self(tmp_path, subdivide_coords):
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == len(input_layerinfo.columns)
     assert output_layerinfo.featurecount == 3
-
-
-@pytest.mark.parametrize(
-    "kwargs, expected_error",
-    [
-        ({"erase_path": None}, "erase_layer must be None if erase_path is None"),
-        ({"subdivide_coords": -1}, "subdivide_coords < 0 is not allowed"),
-    ],
-)
-def test_erase_self_invalid_params(kwargs, expected_error):
-    if "erase_path" not in kwargs:
-        kwargs["erase_path"] = "erase.gpkg"
-    with pytest.raises(ValueError, match=expected_error):
-        gfo.erase(
-            input_path="input.gpkg",
-            output_path="output.gpkg",
-            erase_layer="invalid",
-            **kwargs,
-        )
 
 
 @pytest.mark.parametrize("suffix", SUFFIXES_GEOOPS)
@@ -498,6 +498,27 @@ def test_identity_force(tmp_path):
     assert output_path.stat().st_mtime != mtime_orig
 
 
+@pytest.mark.parametrize(
+    "kwargs, expected_error",
+    [
+        (
+            {"input2_path": None, "input2_layer": "invalid"},
+            "input2_layer must be None if input2_path is None",
+        ),
+        ({"subdivide_coords": -1}, "subdivide_coords < 0 is not allowed"),
+    ],
+)
+def test_identity_invalid_params(kwargs, expected_error):
+    if "input2_path" not in kwargs:
+        kwargs["input2_path"] = "input2.gpkg"
+    with pytest.raises(ValueError, match=expected_error):
+        gfo.identity(
+            input1_path="input1.gpkg",
+            output_path="output.gpkg",
+            **kwargs,
+        )
+
+
 def test_identity_self(tmp_path):
     input1_path = test_helper.get_testfile("polygon-overlappingcircles-all")
     input1_layerinfo = gfo.get_layerinfo(input1_path)
@@ -519,18 +540,6 @@ def test_identity_self(tmp_path):
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == 2 * len(input1_layerinfo.columns)
     assert output_layerinfo.featurecount == 9
-
-
-def test_identity_self_invalid_params():
-    with pytest.raises(
-        ValueError, match="input2_layer must be None if input2_path is None"
-    ):
-        gfo.identity(
-            input1_path="input.gpkg",
-            input2_path=None,
-            output_path="output.gpkg",
-            input2_layer="invalid",
-        )
 
 
 @pytest.mark.parametrize("testfile", ["polygon-parcel"])
@@ -678,6 +687,26 @@ def test_intersection_invalid_params(
         )
 
 
+@pytest.mark.parametrize(
+    "kwargs, expected_error",
+    [
+        (
+            {"input2_path": None, "input2_layer": "invalid"},
+            "input2_layer must be None if input2_path is None",
+        )
+    ],
+)
+def test_intersection_invalid_params2(kwargs, expected_error):
+    if "input2_path" not in kwargs:
+        kwargs["input2_path"] = "input2.gpkg"
+    with pytest.raises(ValueError, match=expected_error):
+        gfo.intersection(
+            input1_path="input1.gpkg",
+            output_path="output.gpkg",
+            **kwargs,
+        )
+
+
 def test_intersection_output_path_exists(tmp_path):
     # Prepare test data
     input1_path = test_helper.get_testfile("polygon-parcel")
@@ -766,18 +795,6 @@ def test_intersection_self(tmp_path):
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == 2 * len(input1_layerinfo.columns)
     assert output_layerinfo.featurecount == 6
-
-
-def test_intersection_self_invalid_params():
-    with pytest.raises(
-        ValueError, match="input2_layer must be None if input2_path is None"
-    ):
-        gfo.intersection(
-            input1_path="input.gpkg",
-            input2_path=None,
-            output_path="output.gpkg",
-            input2_layer="invalid",
-        )
 
 
 @pytest.mark.parametrize("testfile", ["polygon-parcel"])
@@ -1637,6 +1654,27 @@ def test_symmetric_difference(tmp_path, suffix, epsg, gridsize):
     )
 
 
+@pytest.mark.parametrize(
+    "kwargs, expected_error",
+    [
+        (
+            {"input2_path": None, "input2_layer": "invalid"},
+            "input2_layer must be None if input2_path is None",
+        ),
+        ({"subdivide_coords": -1}, "subdivide_coords < 0 is not allowed"),
+    ],
+)
+def test_symmetric_difference_invalid_params(kwargs, expected_error):
+    if "input2_path" not in kwargs:
+        kwargs["input2_path"] = "input2.gpkg"
+    with pytest.raises(ValueError, match=expected_error):
+        gfo.symmetric_difference(
+            input1_path="input1.gpkg",
+            output_path="output.gpkg",
+            **kwargs,
+        )
+
+
 def test_symmetric_difference_self(tmp_path):
     input1_path = test_helper.get_testfile("polygon-overlappingcircles-all")
     input1_layerinfo = gfo.get_layerinfo(input1_path)
@@ -1658,18 +1696,6 @@ def test_symmetric_difference_self(tmp_path):
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == 2 * len(input1_layerinfo.columns)
     assert output_layerinfo.featurecount == 6
-
-
-def test_symmetric_difference_self_invalid_params():
-    with pytest.raises(
-        ValueError, match="input2_layer must be None if input2_path is None"
-    ):
-        gfo.symmetric_difference(
-            input1_path="input.gpkg",
-            input2_path=None,
-            output_path="output.gpkg",
-            input2_layer="invalid",
-        )
 
 
 @pytest.mark.parametrize(
@@ -1907,6 +1933,27 @@ def test_union_force(tmp_path):
     assert output_path.stat().st_mtime != mtime_orig
 
 
+@pytest.mark.parametrize(
+    "kwargs, expected_error",
+    [
+        (
+            {"input2_path": None, "input2_layer": "invalid"},
+            "input2_layer must be None if input2_path is None",
+        ),
+        ({"subdivide_coords": -1}, "subdivide_coords < 0 is not allowed"),
+    ],
+)
+def test_union_invalid_params(kwargs, expected_error):
+    if "input2_path" not in kwargs:
+        kwargs["input2_path"] = "input2.gpkg"
+    with pytest.raises(ValueError, match=expected_error):
+        gfo.union(
+            input1_path="input.gpkg",
+            output_path="output.gpkg",
+            **kwargs,
+        )
+
+
 def test_union_self(tmp_path):
     input1_path = test_helper.get_testfile("polygon-overlappingcircles-all")
     input1_layerinfo = gfo.get_layerinfo(input1_path)
@@ -1928,15 +1975,3 @@ def test_union_self(tmp_path):
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == 2 * len(input1_layerinfo.columns)
     assert output_layerinfo.featurecount == 12
-
-
-def test_union_self_invalid_params():
-    with pytest.raises(
-        ValueError, match="input2_layer must be None if input2_path is None"
-    ):
-        gfo.union(
-            input1_path="input.gpkg",
-            input2_path=None,
-            output_path="output.gpkg",
-            input2_layer="invalid",
-        )


### PR DESCRIPTION
No erasing was done at all in this case...

Same problem for all depending operations: so fixes `erase`, `identity`, `symmetric_difference` and `union`.

Resolves #489 