### PR TITLE
ENH: Remove the column "spatial_relation" from the output of `join_by_location`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@
 
 - Set the default value of `keep_empty_geoms` to `False` for all standard operations.
   This changes the default for `make_valid` and in some cases for `simplify`. The only
-  exception is `select`, where the default stays `True` (#472, #499).
+  exception is `select`, where the default stays `True`. (#472, #499)
+- When `join_by_location` was applied, a column "spatial_relation" with the spatial
+  relation between the geometries was added. This is no longer the case. (#)
 
 ## 0.8.1 (2024-01-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
   This changes the default for `make_valid` and in some cases for `simplify`. The only
   exception is `select`, where the default stays `True`. (#472, #499)
 - When `join_by_location` was applied, a column "spatial_relation" with the spatial
-  relation between the geometries was added. This is no longer the case. (#)
+  relation between the geometries was added. This is no longer the case. (#475)
 
 ## 0.8.1 (2024-01-13)
 

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -1620,7 +1620,6 @@ def join_by_location(
         SELECT sub.geom
               {{layer1_columns_from_subselect_str}}
               {{layer2_columns_from_subselect_str}}
-              ,sub."GFO_$TEMP$_SPATIAL_RELATION" AS spatial_relation
               {area_inters_column_in_output}
           FROM layer1_relations_filtered sub
     """

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -1630,10 +1630,9 @@ def join_by_location(
         sql_template = f"""
             {sql_template}
             UNION ALL
-            SELECT layer1.{{input1_geometrycolumn}} as geom
+            SELECT layer1.{{input1_geometrycolumn}} AS geom
                   {{layer1_columns_prefix_alias_str}}
                   {{layer2_columns_prefix_alias_null_str}}
-                  ,NULL AS spatial_relation
                   {area_inters_column_0_in_output}
               FROM {{input1_databasename}}."{{input1_layer}}" layer1
              WHERE 1=1

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -1004,7 +1004,7 @@ def test_join_by_location(
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert output_layerinfo.featurecount == expected_featurecount
 
-    exp_nb_columns = len(input1_layerinfo.columns) + len(input2_layerinfo.columns) + 1
+    exp_nb_columns = len(input1_layerinfo.columns) + len(input2_layerinfo.columns)
     if area_inters_column_name is not None:
         assert area_inters_column_name in output_layerinfo.columns
         exp_nb_columns += 1


### PR DESCRIPTION
This opens the way to improve performance of `join by location`, because determining the exact relation is relatively expensive.

resolves #475 
related to #502 