### PR TITLE
ENH: use the gdal default to create a spatial index on output files or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Set the default value of `keep_empty_geoms` to `False` for all standard operations.
   This changes the default for `make_valid` and in some cases for `simplify`. The only
   exception is `select`, where the default stays `True`. (#472, #499)
+- Use the GDAL default to create a spatial index or not for output files. (#511)
 - The default filter clause for `export_by_location` is now "intersects is True" while 
   in previous versions it was "intersects is True and touches is False", to be in line with `join_by_location`, other libraries and use for non-polygon data. (#508)
 - When `join_by_location` was applied, a column "spatial_relation" with the spatial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@
 - Set the default value of `keep_empty_geoms` to `False` for all standard operations.
   This changes the default for `make_valid` and in some cases for `simplify`. The only
   exception is `select`, where the default stays `True`. (#472, #499)
-- Use the GDAL default to create a spatial index or not for output files. (#511)
+- Up to now, geofileops always tried to create spatial indexes on output files. For some
+  formats this has disadvantages thought. Hence, and for consistency, from now on the
+  default behaviour regarding spatial index creation of GDAL will be followed. E.g.
+  default a spatial index for "GPKG", but no index for "ESRI Shapefile". (#511)
 - The default filter clause for `export_by_location` is now "intersects is True" while 
   in previous versions it was "intersects is True and touches is False", to be in line with `join_by_location`, other libraries and use for non-polygon data. (#508)
 - When `join_by_location` was applied, a column "spatial_relation" with the spatial

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -691,7 +691,7 @@ def remove_spatial_index(
         elif path_info.driver == "ESRI Shapefile":
             # DROP SPATIAL INDEX ON ... command gives an error, so just remove .qix
             index_path = path.parent / f"{path.stem}.qix"
-            index_path.unlink()
+            index_path.unlink(missing_ok=True)
         else:
             raise ValueError(
                 f"remove_spatial_index not supported for {path_info.driver}: {path}"
@@ -1479,7 +1479,7 @@ def to_file(
     append: bool = False,
     append_timeout_s: int = 600,
     index: Optional[bool] = None,
-    create_spatial_index: Optional[bool] = True,
+    create_spatial_index: Optional[bool] = None,
 ):
     """
     Writes a pandas dataframe to file.
@@ -1517,7 +1517,7 @@ def to_file(
             If False, no index is written. Defaults to None.
         create_spatial_index (bool, optional): True to force creation of spatial index,
             False to avoid creation. None leads to the default behaviour of gdal.
-            Defaults to True.
+            Defaults to None.
 
     Raises:
         ValueError: an invalid parameter value was passed.
@@ -1598,7 +1598,7 @@ def _to_file_fiona(
     append: bool = False,
     append_timeout_s: int = 600,
     index: Optional[bool] = None,
-    create_spatial_index: Optional[bool] = True,
+    create_spatial_index: Optional[bool] = None,
 ):
     """
     Writes a pandas dataframe to file using fiona.
@@ -1659,7 +1659,7 @@ def _to_file_fiona(
         force_multitype: bool = False,
         append: bool = False,
         schema: Optional[dict] = None,
-        create_spatial_index: Optional[bool] = True,
+        create_spatial_index: Optional[bool] = None,
     ):
         # Prepare args for to_file
         if append is True:
@@ -1801,7 +1801,7 @@ def _to_file_pyogrio(
     append: bool = False,
     append_timeout_s: int = 600,
     index: Optional[bool] = None,
-    create_spatial_index: Optional[bool] = True,
+    create_spatial_index: Optional[bool] = None,
 ):
     """
     Writes a pandas dataframe to file using pyogrio.
@@ -1830,8 +1830,6 @@ def _to_file_pyogrio(
     path_info = _geofileinfo.get_geofileinfo(path)
     kwargs["driver"] = path_info.driver
     kwargs["index"] = index
-    if create_spatial_index is not None:
-        kwargs["SPATIAL_INDEX"] = create_spatial_index
     if force_output_geometrytype is not None:
         if isinstance(force_output_geometrytype, GeometryType):
             force_output_geometrytype = force_output_geometrytype.name_camelcase
@@ -2059,7 +2057,7 @@ def append_to(
     reproject: bool = False,
     explodecollections: bool = False,
     force_output_geometrytype: Union[GeometryType, str, None] = None,
-    create_spatial_index: Optional[bool] = True,
+    create_spatial_index: Optional[bool] = None,
     append_timeout_s: int = 600,
     transaction_size: int = 50000,
     preserve_fid: Optional[bool] = None,
@@ -2138,7 +2136,7 @@ def append_to(
             that file type is respected. If the `LAYER_CREATION.SPATIAL_INDEX`
             parameter is specified in options, `create_spatial_index` is ignored. If the
             destination layer exists already, `create_spatial_index` is also ignored.
-            Defaults to True.
+            Defaults to None.
         append_timeout_s (int, optional): timeout to use if the output file is
             being written to by another process already. Defaults to 600.
         transaction_size (int, optional): Transaction size. Defaults to 50000.
@@ -2238,7 +2236,7 @@ def _append_to_nolock(
     sql_dialect: Optional[Literal["SQLITE", "OGRSQL"]] = None,
     reproject: bool = False,
     explodecollections: bool = False,
-    create_spatial_index: Optional[bool] = True,
+    create_spatial_index: Optional[bool] = None,
     force_output_geometrytype: Union[GeometryType, str, None] = None,
     transaction_size: int = 50000,
     preserve_fid: Optional[bool] = None,
@@ -2350,7 +2348,7 @@ def convert(
     reproject: bool = False,
     explodecollections: bool = False,
     force_output_geometrytype: Union[GeometryType, str, None] = None,
-    create_spatial_index: Optional[bool] = True,
+    create_spatial_index: Optional[bool] = None,
     preserve_fid: Optional[bool] = None,
     options: dict = {},
     append: bool = False,
@@ -2393,7 +2391,7 @@ def copy_layer(
     reproject: bool = False,
     explodecollections: bool = False,
     force_output_geometrytype: Union[GeometryType, str, None] = None,
-    create_spatial_index: Optional[bool] = True,
+    create_spatial_index: Optional[bool] = None,
     preserve_fid: Optional[bool] = None,
     dst_dimensions: Optional[str] = None,
     options: dict = {},
@@ -2460,7 +2458,7 @@ def copy_layer(
             on the destination file/layer. If None, the default behaviour by gdal for
             that file type is respected. If the LAYER_CREATION.SPATIAL_INDEX
             parameter is specified in options, create_spatial_index is ignored.
-            Defaults to True.
+            Defaults to None.
         preserve_fid (bool, optional): True to make an extra effort to preserve fid's of
             the source layer to the destination layer. False not to do any effort. None
             to use the default behaviour of gdal, that already preserves in some cases.

--- a/geofileops/util/_geofileinfo.py
+++ b/geofileops/util/_geofileinfo.py
@@ -31,6 +31,7 @@ class GeofileTypeInfo:
     suffixes: List[str]
     is_fid_zerobased: bool
     is_spatialite_based: bool
+    default_spatial_index: bool
     suffixes_extrafiles: List[str]
 
 
@@ -67,6 +68,7 @@ def _init_geofiletypes():
                 suffixes=suffixes,
                 is_fid_zerobased=ast.literal_eval(row["is_fid_zerobased"]),
                 is_spatialite_based=ast.literal_eval(row["is_spatialite_based"]),
+                default_spatial_index=ast.literal_eval(row["default_spatial_index"]),
                 suffixes_extrafiles=suffixes_extrafiles,
             )
 
@@ -214,6 +216,14 @@ class GeofileInfo:
             return False
         else:
             return True
+
+    @property
+    def default_spatial_index(self) -> bool:
+        """Returns True if this geofile can only have one layer."""
+        if self.geofiletype_info is not None:
+            return self.geofiletype_info.default_spatial_index
+        else:
+            return False
 
     @property
     def suffixes_extrafiles(self) -> List[str]:

--- a/geofileops/util/_geoops_ogr.py
+++ b/geofileops/util/_geoops_ogr.py
@@ -27,7 +27,6 @@ def clip_by_geometry(
         geom = wkt.loads(clip_geometry)
         spatial_filter = tuple(geom.bounds)
 
-    options = {"LAYER_CREATION.SPATIAL_INDEX": True}
     _run_ogr(
         operation="clip_by_geometry",
         input_path=input_path,
@@ -38,7 +37,6 @@ def clip_by_geometry(
         output_layer=output_layer,
         columns=columns,
         explodecollections=explodecollections,
-        options=options,
         force=force,
     )
 
@@ -53,7 +51,6 @@ def export_by_bounds(
     explodecollections: bool = False,
     force: bool = False,
 ):
-    options = {"LAYER_CREATION.SPATIAL_INDEX": True}
     _run_ogr(
         operation="export_by_bounds",
         input_path=input_path,
@@ -63,7 +60,6 @@ def export_by_bounds(
         output_layer=output_layer,
         columns=columns,
         explodecollections=explodecollections,
-        options=options,
         force=force,
     )
 

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -893,7 +893,7 @@ def clip(
     batchsize: int = -1,
     force: bool = False,
     input_columns_prefix: str = "",
-    output_with_spatial_index: bool = True,
+    output_with_spatial_index: Optional[bool] = None,
 ):
     # Init
     # In the query, important to only extract the geometry types that are expected
@@ -999,7 +999,7 @@ def erase(
     subdivide_coords: int = 2000,
     force: bool = False,
     input_columns_prefix: str = "",
-    output_with_spatial_index: bool = True,
+    output_with_spatial_index: Optional[bool] = None,
     operation_prefix: str = "",
 ):
     # Because there might be extra preparation of the erase layer before going ahead
@@ -1495,7 +1495,7 @@ def intersection(
     nb_parallel: int = -1,
     batchsize: int = -1,
     force: bool = False,
-    output_with_spatial_index: bool = True,
+    output_with_spatial_index: Optional[bool] = None,
     operation_prefix: str = "",
 ):
     # If we are doing a self overlay, we need to filter out rows with the same rowid.
@@ -2041,7 +2041,7 @@ def select_two_layers(
     batchsize: int = -1,
     force: bool = False,
     operation_prefix: str = "",
-    output_with_spatial_index: bool = True,
+    output_with_spatial_index: Optional[bool] = None,
 ):
     # Go!
     return _two_layer_vector_operation(

--- a/geofileops/util/geofiletypes.csv
+++ b/geofileops/util/geofiletypes.csv
@@ -1,6 +1,6 @@
-geofiletype,   ogrdriver,        suffixes,              is_fid_zerobased, is_spatialite_based, suffixes_extrafiles
-ESRIShapefile, "ESRI Shapefile", "['.shp', '.dbf']",    True,             False,               "['.shp', '.dbf', '.shx', '.prj', '.qix', '.sbn', '.sbx']"
-GeoJSON,       GeoJSON,          "['.geojson']",        True,             False,               
-GPKG,          GPKG,             "['.gpkg']",           False,            True,                "['gpkg-journal']"
-SQLite,        SQLite,           "['.sqlite']",         False,            True,                
-FlatGeobuf,    FlatGeobuf,       "['.fgb']",            True,             False,               
+geofiletype,   ogrdriver,        suffixes,              is_fid_zerobased, is_spatialite_based, default_spatial_index, suffixes_extrafiles
+ESRIShapefile, "ESRI Shapefile", "['.shp', '.dbf']",    True,             False,               False,                 "['.shp', '.dbf', '.shx', '.prj', '.qix', '.sbn', '.sbx']"
+GeoJSON,       GeoJSON,          "['.geojson']",        True,             False,               False,                 
+GPKG,          GPKG,             "['.gpkg']",           False,            True,                True,                  "['gpkg-journal']"
+SQLite,        SQLite,           "['.sqlite']",         False,            True,                True,                  
+FlatGeobuf,    FlatGeobuf,       "['.fgb']",            True,             False,               True,                  

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -14,6 +14,7 @@ import shapely.geometry as sh_geom
 import geofileops as gfo
 from geofileops import fileops
 from geofileops.util import _geofileinfo
+from geofileops.util._geofileinfo import GeofileInfo
 from geofileops.util import _geoseries_util
 from geofileops.util import _io_util
 from geofileops.util import _ogr_util
@@ -1159,10 +1160,11 @@ def test_spatial_index(tmp_path, suffix):
         "polygon-parcel", dst_dir=tmp_path, suffix=suffix
     )
     layer = gfo.get_only_layer(test_path)
+    default_spatial_index = GeofileInfo(test_path).default_spatial_index
 
     # Check if spatial index present
     has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
-    assert has_spatial_index is True
+    assert has_spatial_index is default_spatial_index
 
     # Remove spatial index
     gfo.remove_spatial_index(path=test_path, layer=layer)

--- a/tests/test_geofileops_singlelayer.py
+++ b/tests/test_geofileops_singlelayer.py
@@ -17,6 +17,7 @@ from geofileops import GeometryType
 from geofileops import geoops
 from geofileops._compat import SPATIALITE_GTE_51
 from geofileops.util import _geofileinfo
+from geofileops.util._geofileinfo import GeofileInfo
 from geofileops.util import _geoops_sql
 from geofileops.util import _io_util as io_util
 
@@ -215,7 +216,8 @@ def test_buffer(
 
     # Now check if the output file is correctly created
     assert output_path.exists()
-    assert fileops.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert fileops.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = fileops.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == len(input_layerinfo.columns)
 
@@ -276,7 +278,8 @@ def test_buffer_columns_fid(tmp_path, suffix, geoops_module, testfile):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
-    assert fileops.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert fileops.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = fileops.get_layerinfo(output_path)
     output_gdf = fileops.read_file(output_path)
     assert output_gdf["geometry"][0] is not None
@@ -307,7 +310,8 @@ def test_buffer_force(tmp_path, geoops_module):
 
     # Test buffer to existing output path
     assert output_path.exists()
-    assert fileops.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert fileops.has_spatial_index(output_path) is exp_spatial_index
     mtime_orig = output_path.stat().st_mtime
     geoops.buffer(
         input_path=input_path,
@@ -412,7 +416,7 @@ def test_buffer_negative(
 
     # Now check if the output file is correctly created
     assert output_path.exists()
-    assert fileops.has_spatial_index(output_path)
+
     output_layerinfo = fileops.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == len(input_layerinfo.columns)
 
@@ -482,7 +486,8 @@ def test_buffer_negative_explode(tmp_path, geoops_module):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
-    assert fileops.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert fileops.has_spatial_index(output_path) is exp_spatial_index
     layerinfo_output = fileops.get_layerinfo(output_path)
     assert len(layerinfo_output.columns) == len(input_layerinfo.columns)
     assert layerinfo_output.geometrytype == GeometryType.POLYGON
@@ -544,7 +549,8 @@ def test_buffer_negative_where_explode(
 
     # Check result
     assert output_path.exists()
-    assert fileops.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert fileops.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = fileops.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == len(input_layerinfo.columns)
 
@@ -597,7 +603,8 @@ def test_buffer_preserve_fid_gpkg(tmp_path, geoops_module):
 
     # Check if the output file with the expected result
     assert output_path.exists()
-    assert fileops.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert fileops.has_spatial_index(output_path) is exp_spatial_index
     output_gdf = fileops.read_file(output_path, fid_as_index=True)
     assert len(output_gdf) == len(expected_gdf)
     assert output_gdf["geometry"].iloc[0] is not None
@@ -648,7 +655,8 @@ def test_buffer_shp_to_gpkg(
 
     # Now check if the output file is correctly created
     assert output_path.exists()
-    assert fileops.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert fileops.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = fileops.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == len(input_layerinfo.columns)
 
@@ -714,7 +722,8 @@ def test_convexhull(
 
     # Now check if the output file is correctly created
     assert output_path.exists()
-    assert fileops.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert fileops.has_spatial_index(output_path) is exp_spatial_index
     layerinfo_output = fileops.get_layerinfo(output_path)
     assert "OIDN" in layerinfo_output.columns
     assert "uidn" in layerinfo_output.columns
@@ -1111,7 +1120,8 @@ def test_simplify(
 
     # Now check if the tmp file is correctly created
     assert output_path.exists()
-    assert fileops.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert fileops.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = fileops.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == len(input_layerinfo.columns)
 

--- a/tests/test_geofileops_singlelayer_gpd.py
+++ b/tests/test_geofileops_singlelayer_gpd.py
@@ -88,7 +88,8 @@ def test_apply(
 
     # Now check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
 
     # Read result for some more detailed checks
     output_gdf = gfo.read_file(output_path).sort_values("uidn").reset_index(drop=True)
@@ -175,7 +176,8 @@ def test_apply_None(tmp_path, suffix, only_geom_input, force_output_geometrytype
 
     # Now check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
 
     # Read result for some more detailed checks
     output_gdf = gfo.read_file(output_path).sort_values("id").reset_index(drop=True)
@@ -589,7 +591,8 @@ def test_dissolve_polygons(
 
     # Now check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     assert gfo.isvalid(output_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert output_layerinfo.featurecount == expected_featurecount
@@ -1138,7 +1141,8 @@ def test_simplify_lang(tmp_path, suffix, epsg, testfile, gridsize):
 
     # Check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     expected_featurecount = input_layerinfo.featurecount
     if testfile == "polygon-parcel":
@@ -1198,7 +1202,8 @@ def test_simplify_vw(tmp_path, suffix, epsg, testfile, gridsize):
 
     # Check if the file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     expected_featurecount = input_layerinfo.featurecount
     if testfile == "polygon-parcel":

--- a/tests/test_geofileops_singlelayer_gpd.py
+++ b/tests/test_geofileops_singlelayer_gpd.py
@@ -15,6 +15,7 @@ import shapely.geometry as sh_geom
 import geofileops as gfo
 from geofileops import GeometryType
 from geofileops.util import _geofileinfo
+from geofileops.util._geofileinfo import GeofileInfo
 from geofileops.util import _geometry_util
 from geofileops.util import _geoops_gpd as geoops_gpd
 from tests import test_helper
@@ -311,7 +312,8 @@ def test_dissolve_linestrings(
 
     # Check if the result file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert output_layerinfo.geometrytype in [
         GeometryType.LINESTRING,

--- a/tests/test_geofileops_singlelayer_ogr.py
+++ b/tests/test_geofileops_singlelayer_ogr.py
@@ -1,11 +1,12 @@
 """
-Tests for operations using GeoPandas.
+Tests for operations using only gdal.
 """
 
 import pytest
 
 import geofileops as gfo
 from geofileops import GeometryType
+from geofileops.util._geofileinfo import GeofileInfo
 from tests import test_helper
 from tests.test_helper import SUFFIXES_GEOOPS
 
@@ -30,7 +31,8 @@ def test_clip_by_geometry(tmp_path, suffix):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     layerinfo_orig = gfo.get_layerinfo(input_path)
     layerinfo_output = gfo.get_layerinfo(output_path)
     assert layerinfo_output.featurecount == 22
@@ -63,7 +65,8 @@ def test_export_by_bounds(tmp_path, suffix):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     layerinfo_orig = gfo.get_layerinfo(input_path)
     layerinfo_output = gfo.get_layerinfo(output_path)
     assert layerinfo_output.featurecount == 25
@@ -116,7 +119,8 @@ def test_warp(tmp_path):
 
     # Now check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     layerinfo_orig = gfo.get_layerinfo(input_path)
     layerinfo_output = gfo.get_layerinfo(output_path)
     assert layerinfo_output.featurecount == layerinfo_orig.featurecount

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -17,6 +17,7 @@ import geofileops as gfo
 from geofileops import GeometryType
 from geofileops._compat import SPATIALITE_GTE_51
 from geofileops.util import _geofileinfo
+from geofileops.util._geofileinfo import GeofileInfo
 from geofileops.util import _geoops_sql as geoops_sql
 from tests import test_helper
 from tests.test_helper import SUFFIXES_GEOOPS, TESTFILES
@@ -550,7 +551,8 @@ def test_identity(tmp_path, suffix, epsg, gridsize):
 
     # Check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     input2_layerinfo = gfo.get_layerinfo(input2_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert (len(input1_layerinfo.columns) + len(input2_layerinfo.columns)) == len(
@@ -1761,7 +1763,8 @@ def test_symmetric_difference(tmp_path, suffix, epsg, gridsize):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_gdf = gfo.read_file(output_path)
     assert output_gdf["geometry"][0] is not None
 
@@ -1891,7 +1894,8 @@ def test_union(
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     exp_columns = len(input1_layerinfo.columns) + len(input2_layerinfo.columns)
     if keep_fid:
@@ -1965,7 +1969,8 @@ def test_union_circles(tmp_path, suffix, epsg):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     input2_layerinfo = gfo.get_layerinfo(input2_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert output_layerinfo.featurecount == 5

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -42,7 +42,8 @@ def test_clip(tmp_path, testfile, suffix):
 
     # Compare result with geopandas
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_gdf = gfo.read_file(output_path)
     input_gdf = gfo.read_file(input_path)
     clip_gdf = gfo.read_file(clip_path)
@@ -88,7 +89,8 @@ def test_clip_resultempty(tmp_path, suffix, clip_empty):
 
     # Check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert output_layerinfo.featurecount == 0
     assert len(output_layerinfo.columns) == len(input_layerinfo.columns)
@@ -137,7 +139,8 @@ def test_erase(tmp_path, suffix, testfile, gridsize, where_post, subdivide_coord
 
     # Compare result with geopandas
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_gdf = gfo.read_file(output_path)
     input_gdf = gfo.read_file(input_path)
     erase_gdf = gfo.read_file(erase_path, layer=erase_layer)
@@ -191,7 +194,8 @@ def test_erase_explodecollections(tmp_path):
 
     # Compare result with geopandas
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_gdf = gfo.read_file(output_path)
     input_gdf = gfo.read_file(input_path)
     erase_gdf = gfo.read_file(erase_path)
@@ -273,7 +277,8 @@ def test_erase_self(tmp_path, subdivide_coords):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == len(input_layerinfo.columns)
     assert output_layerinfo.featurecount == 3
@@ -326,7 +331,8 @@ def test_erase_subdivide_multipolygons(tmp_path, suffix):
 
     # Compare result with geopandas
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_gdf = gfo.read_file(output_path)
     input_gdf = gfo.read_file(input_path)
     output_gpd_gdf = gpd.overlay(
@@ -380,7 +386,8 @@ def test_export_by_location(
 
     # Check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     exp_columns = len(input_layerinfo.columns) if columns is None else len(columns)
     assert len(output_layerinfo.columns) == exp_columns
@@ -431,7 +438,8 @@ def test_export_by_location_area(
 
     # Check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     exp_columns = len(input_layerinfo.columns)
     exp_area_inters_column_name = area_inters_column_name
@@ -484,7 +492,8 @@ def test_export_by_location_query(tmp_path, query, exp_featurecount):
 
     # Check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     exp_columns = len(input_layerinfo.columns)
     assert len(output_layerinfo.columns) == exp_columns
@@ -516,7 +525,8 @@ def test_export_by_distance(tmp_path, testfile, suffix):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(input_to_select_from_path)
     assert input_layerinfo.featurecount == output_layerinfo.featurecount
     assert len(input_layerinfo.columns) == len(output_layerinfo.columns)
@@ -652,7 +662,8 @@ def test_identity_self(tmp_path):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == 2 * len(input1_layerinfo.columns)
     assert output_layerinfo.featurecount == 9
@@ -696,7 +707,8 @@ def test_intersection(
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     input2_layerinfo = gfo.get_layerinfo(input2_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == (
@@ -880,7 +892,8 @@ def test_intersection_resultempty(tmp_path, suffix, input2_empty):
 
     # Check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert output_layerinfo.featurecount == 0
     input2_layerinfo = gfo.get_layerinfo(input2_path)
@@ -907,7 +920,8 @@ def test_intersection_self(tmp_path):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == 2 * len(input1_layerinfo.columns)
     assert output_layerinfo.featurecount == 6
@@ -940,7 +954,8 @@ def test_intersection_columns_fid(tmp_path, testfile, suffix):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == len(input1_columns) + len(input2_columns)
     assert output_layerinfo.geometrytype == GeometryType.MULTIPOLYGON
@@ -996,7 +1011,8 @@ def test_intersection_where_post(
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     input2_layerinfo = gfo.get_layerinfo(input2_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == (
@@ -1130,7 +1146,8 @@ def test_join_by_location(
 
     # Check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     input2_layerinfo = gfo.get_layerinfo(input2_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert output_layerinfo.featurecount == exp_featurecount
@@ -1179,7 +1196,8 @@ def test_join_nearest(tmp_path, suffix, epsg):
 
     # Check if the output file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     input2_layerinfo = gfo.get_layerinfo(input2_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     expected_featurecount = nb_nearest * (input1_layerinfo.featurecount - 1)
@@ -1290,7 +1308,8 @@ def test_select_two_layers(tmp_path, suffix, epsg, gridsize):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     input1_layerinfo = gfo.get_layerinfo(input1_path)
     input2_layerinfo = gfo.get_layerinfo(input2_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
@@ -1385,7 +1404,8 @@ def test_select_two_layers_input_without_geom(tmp_path, suffix, input_nogeom):
     # Check if the tmp file is correctly created
     assert output_path.exists()
     if exp_output_geom:
-        assert gfo.has_spatial_index(output_path)
+        exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+        assert gfo.has_spatial_index(output_path) is exp_spatial_index
 
     input1_layerinfo = gfo.get_layerinfo(input1_path, raise_on_nogeom=False)
     input2_layerinfo = gfo.get_layerinfo(input2_path, raise_on_nogeom=False)
@@ -1574,7 +1594,8 @@ def test_select_two_layers_no_databasename_placeholder(tmp_path):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     input1_layerinfo = gfo.get_layerinfo(input1_path)
     input2_layerinfo = gfo.get_layerinfo(input2_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
@@ -1711,7 +1732,8 @@ def test_split(tmp_path):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     input2_layerinfo = gfo.get_layerinfo(input2_path)
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert output_layerinfo.featurecount == 68
@@ -1832,7 +1854,8 @@ def test_symmetric_difference_self(tmp_path):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == 2 * len(input1_layerinfo.columns)
     assert output_layerinfo.featurecount == 6
@@ -2113,7 +2136,8 @@ def test_union_self(tmp_path):
 
     # Check if the tmp file is correctly created
     assert output_path.exists()
-    assert gfo.has_spatial_index(output_path)
+    exp_spatial_index = GeofileInfo(output_path).default_spatial_index
+    assert gfo.has_spatial_index(output_path) is exp_spatial_index
     output_layerinfo = gfo.get_layerinfo(output_path)
     assert len(output_layerinfo.columns) == 2 * len(input1_layerinfo.columns)
     assert output_layerinfo.featurecount == 12

--- a/tests/test_sqlite_util.py
+++ b/tests/test_sqlite_util.py
@@ -10,6 +10,7 @@ import pytest
 from geofileops import fileops
 import geofileops as gfo
 from geofileops.util import _sqlite_util as sqlite_util
+from geofileops.util._geofileinfo import GeofileInfo
 from tests import test_helper
 from tests.test_helper import assert_geodataframe_equal
 
@@ -111,7 +112,8 @@ def test_create_table_as_sql_invalidparams(kwargs, expected_error):
 
 def test_execute_sql(tmp_path):
     test_path = test_helper.get_testfile(testfile="polygon-parcel", dst_dir=tmp_path)
-    assert gfo.has_spatial_index(test_path)
+    exp_spatial_index = GeofileInfo(test_path).default_spatial_index
+    assert gfo.has_spatial_index(test_path) is exp_spatial_index
     info_input = gfo.get_layerinfo(test_path)
     nb_deleted = 0
 


### PR DESCRIPTION
Now, geofileops always tries to create a spatial index on output files.

For some file formats this isn't relevant though (e.g. .csv), and for some file formats this creates risks for later issues (e.g. the spatial index for shapefile isn't kept up-to-date if the shapefile is updated afterwards).

So, it is most logical just to follow/copy the default behaviour by GDAL.