### PR TITLE
MAINT: update geopandas dependency to support 1.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
         extra: ["nomkl"]
         include:
-          - env: minimal-fiona
+          - env: minimal
             os: ubuntu-latest
             dev: false
             python: "3.9"

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -15,8 +15,9 @@ dependencies:
   - pandas =1.4  # released 2022-01-28
   - psutil
   - pygeoops =0.4  # released 2023-11-24
+  - pygeos
   - pyogrio =0.7  # 0.7.0 released 2023-10-25
-  - pyproj =3.4  # released 2022-09-10
+  - pyproj =3.5  # released 2023-03-28
   - shapely >=2,<2.1  # released 2022-12-12
   # testing
   - pytest

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   # required
   - cloudpickle
-  - gdal =3.6  # 3.7.0 released 2023-05-03
+  - gdal =3.7  # 3.7.0 released 2023-05-03
   - geopandas-base =0.12  # released 2022-10-24
   - libspatialite =5.0  #  knn index replaced by knn2 in 5.1
   - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -16,7 +16,7 @@ dependencies:
   - psutil
   - pygeoops =0.4  # released 2023-11-24
   - pygeos
-  - pyogrio =0.5.1  # released 2023-01-26
+  - pyogrio =0.7.2  # released 2023-10-25
   - pyproj =3.4  # released 2022-09-10
   - shapely >=2,<2.1  # released 2022-12-12
   # testing

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   # required
   - cloudpickle
-  - gdal =3.6.3  # released 2023-03-13
+  - gdal =3.7.2  # 3.7.0 released 2023-05-03
   - geopandas-base =0.12  # released 2022-10-24
   - libspatialite =5.0  #  knn index replaced by knn2 in 5.1
   - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
@@ -16,7 +16,7 @@ dependencies:
   - psutil
   - pygeoops =0.4  # released 2023-11-24
   - pygeos
-  - pyogrio =0.7.2  # released 2023-10-25
+  - pyogrio =0.7.2  # 0.7.0 released 2023-10-25
   - pyproj =3.4  # released 2022-09-10
   - shapely >=2,<2.1  # released 2022-12-12
   # testing

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -16,7 +16,7 @@ dependencies:
   - psutil
   - pygeoops =0.4  # released 2023-11-24
   - pygeos
-  - pyogrio =0.7.0  # 0.7.0 released 2023-10-25
+  - pyogrio =0.7  # 0.7.0 released 2023-10-25
   - pyproj =3.4  # released 2022-09-10
   - shapely >=2,<2.1  # released 2022-12-12
   # testing

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -15,7 +15,6 @@ dependencies:
   - pandas =1.4  # released 2022-01-28
   - psutil
   - pygeoops =0.4  # released 2023-11-24
-  - pygeos
   - pyogrio =0.7  # 0.7.0 released 2023-10-25
   - pyproj =3.4  # released 2022-09-10
   - shapely >=2,<2.1  # released 2022-12-12

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -16,7 +16,7 @@ dependencies:
   - psutil
   - pygeoops =0.4  # released 2023-11-24
   - pyogrio =0.7  # 0.7.0 released 2023-10-25
-  - pyproj =3.5  # released 2023-03-28
+  - pyproj =3.6  # released 2023-03-28
   - shapely >=2,<2.1  # released 2022-12-12
   # testing
   - pytest

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -6,7 +6,6 @@ dependencies:
   - pip
   # required
   - cloudpickle
-  - fiona >=1.8.21  # release 2022-01-07, pinning this specific version is not compatible with gdal version
   - gdal =3.6.3  # released 2023-03-13
   - geopandas-base =0.12  # released 2022-10-24
   - libspatialite =5.0  #  knn index replaced by knn2 in 5.1

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   # required
   - cloudpickle
-  - gdal =3.7.2  # 3.7.0 released 2023-05-03
+  - gdal =3.6  # 3.7.0 released 2023-05-03
   - geopandas-base =0.12  # released 2022-10-24
   - libspatialite =5.0  #  knn index replaced by knn2 in 5.1
   - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
@@ -16,7 +16,7 @@ dependencies:
   - psutil
   - pygeoops =0.4  # released 2023-11-24
   - pygeos
-  - pyogrio =0.7.2  # 0.7.0 released 2023-10-25
+  - pyogrio =0.7.0  # 0.7.0 released 2023-10-25
   - pyproj =3.4  # released 2022-09-10
   - shapely >=2,<2.1  # released 2022-12-12
   # testing

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -15,7 +15,6 @@ dependencies:
   - pandas =1.4  # released 2022-01-28
   - psutil
   - pygeoops =0.4  # released 2023-11-24
-  - pygeos
   - pyogrio =0.7  # 0.7.0 released 2023-10-25
   - pyproj =3.5  # released 2023-03-28
   - shapely >=2,<2.1  # released 2022-12-12

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     install_requires=[
         "cloudpickle",
         "gdal>=3.6,<3.10",
-        "geopandas>=0.12,<1",
+        "geopandas>=0.12,<1.1",
         "numpy",
         "packaging",
         "pandas",


### PR DESCRIPTION
Some tests needed to be changed as well as geopandas 1.0 gives some different results when fiona is used:
- when the file has no geometry, a simple DataFrame is returned
- with a shapefile, a datum column becomes a string

This PR changes some tests to account for this + removes fiona from the "minimal" CI env + updates some other dependency versions to avoid having to complicate tests to support the behaviour of old versions of geopandas with fiona.