### PR TITLE
BUG: fix `dissolve` with `agg_columns` gives sometimes wrong aggregation results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.9.1 (????-??-??)
+
+### Bugs fixed
+
+- For `dissolve`, `agg_columns` aggregations sometimes give wrong results (#541)
+
 ## 0.9.0 (2024-05-26)
 
 ### Deprecations and compatibility notes

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -1600,14 +1600,14 @@ def _dissolve_polygons_pass(
             suffix = output_notonborder_path.suffix
             name = f"{output_notonborder_path.stem}_{batch_id}{suffix}"
             output_notonborder_tmp_partial_path = tempdir / name
-            batches[batch_id][
-                "output_notonborder_tmp_partial_path"
-            ] = output_notonborder_tmp_partial_path
+            batches[batch_id]["output_notonborder_tmp_partial_path"] = (
+                output_notonborder_tmp_partial_path
+            )
             name = f"{output_onborder_path.stem}_{batch_id}{suffix}"
             output_onborder_tmp_partial_path = tempdir / name
-            batches[batch_id][
-                "output_onborder_tmp_partial_path"
-            ] = output_onborder_tmp_partial_path
+            batches[batch_id]["output_onborder_tmp_partial_path"] = (
+                output_onborder_tmp_partial_path
+            )
 
             # Get tile_id if present
             tile_id = tile_row.tile_id if "tile_id" in tile_row._fields else None

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -1749,10 +1749,9 @@ def _dissolve_polygons(
                     # are already in the json column
                     columns_to_read.add("__DISSOLVE_TOJSON")
                 else:
-                    # The first pass, so read all relevant columns to code
-                    # them in json
+                    # The first pass, so read all relevant columns to code them in json
                     if "json" in agg_columns:
-                        agg_columns_needed = agg_columns["json"]
+                        agg_columns_needed = list(agg_columns["json"])
                     elif "columns" in agg_columns:
                         agg_columns_needed = [
                             agg_column["column"]

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -1775,8 +1775,16 @@ def _dissolve_polygons(
             )
 
             if agg_columns is not None and agg_columns_needed is not None:
-                input_gdf["fid_orig"] = input_gdf.index
-                agg_columns_needed.insert(0, "fid_orig")
+                # The fid should be added as well, but make name unique
+                fid_orig_column = "fid_orig"
+                for idx in range(99999):
+                    if idx != 0:
+                        fid_orig_column = f"fid_orig{idx}"
+                    if fid_orig_column not in agg_columns_needed:
+                        break
+
+                input_gdf[fid_orig_column] = input_gdf.index
+                agg_columns_needed.insert(0, fid_orig_column)
 
             break
         except Exception as ex:


### PR DESCRIPTION
fixes #541 

Problem was the following: because of the tiled processing in `dissolve`, geometries crossing the boundaries of the tiles are in two partial result files. The duplicates in attribute results are solved because the column values are saved as json strings in the partial result files, and duplicate json stings are removed before calculating the aggregate attribute values. However, because `set` was used to avoid duplicate columns/keys being stored in the json strings, the order of keys was not fixed, and when the order was different, the duplicates could not be correctly removed.