### PR TITLE
ENH: don't write multi geometries by default in copy_layer,...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   column should be retained (#523)
 - Enable "CURVE" geometrytype files to be processed in the general file and
   layer operations (#558)
+- Don't convert to multi-part geometries by default in `copy_layer`,... (#570)
 - Add configuration option to only warn on dissolve errors (#561)
 
 ## 0.9.1 (2024-07-18)

--- a/geofileops/_compat.py
+++ b/geofileops/_compat.py
@@ -18,3 +18,4 @@ spatialite_version = spatialite_version_info["spatialite_version"]
 SPATIALITE_GTE_51 = version.parse(spatialite_version) >= version.parse("5.1")
 
 GDAL_GTE_38 = version.parse(gdal.__version__) >= version.parse("3.8")
+GDAL_STE_310 = version.parse(gdal.__version__) <= version.parse("3.10")

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -2273,7 +2273,7 @@ def _append_to_nolock(
     reproject: bool = False,
     explodecollections: bool = False,
     create_spatial_index: Optional[bool] = None,
-    force_output_geometrytype: Union[GeometryType, str, None] = None,
+    force_output_geometrytype: Union[GeometryType, str, Iterable[str], None] = None,
     transaction_size: int = 50000,
     preserve_fid: Optional[bool] = None,
     dst_dimensions: Optional[str] = None,

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -107,9 +107,7 @@ def dissolve_within_distance(
         # First dissolve the input.
         #
         # Note: this reduces the complexity of operations to be executed later on.
-        # Note2: this already applies the gridsize, which needs to be applied anyway to
-        # avoid issues when determining the addedpieces_1neighbour later on.
-        # Note2: don' apply gridsize yet
+        # Note2: don't apply gridsize yet
         logger.info(f"Start, with input file {input_path}")
         step = 1
         logger.info(f"Step {step} of {nb_steps}")
@@ -342,6 +340,7 @@ def dissolve_within_distance(
             output_path=parts_to_add_filtered_path,
             sql_stmt=sql_stmt,
             input2_layer=input_layer,
+            explodecollections=True,
             gridsize=0.0,
             nb_parallel=nb_parallel,
             batchsize=batchsize,

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -1023,10 +1023,13 @@ def erase(
     input_layer_info = gfo.get_layerinfo(input_path, input_layer)
     primitivetypeid = input_layer_info.geometrytype.to_primitivetype.value
 
-    # If explodecollections is False and the input type is not point, force the output
-    # type to multi, because erase can cause eg. polygons to be split to multipolygons.
     force_output_geometrytype = input_layer_info.geometrytype
-    if not explodecollections and force_output_geometrytype is not GeometryType.POINT:
+    if explodecollections:
+        force_output_geometrytype = force_output_geometrytype.to_singletype
+    elif force_output_geometrytype is not GeometryType.POINT:
+        # If explodecollections is False and the input type is not point, force the
+        # output type to multi, because erase can cause eg. polygons to be split to
+        # multipolygons.
         force_output_geometrytype = force_output_geometrytype.to_multitype
 
     # Subdivide the erase layer if applicable to speed up further processing.

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -331,6 +331,14 @@ def vector_translate(
                     raise ValueError(f"invalid type in {force_output_geometrytype=}")
         else:
             raise ValueError(f"invalid type for {force_output_geometrytype=}")
+    else:
+        if (
+            input_info.driver == "ESRI Shapefile"
+            and output_info.driver != "ESRI Shapefile"
+        ):
+            # Shapefiles are always reported as singlepart type but can also contain
+            # multiparts geometries, so promote to multi
+            output_geometrytypes.append("PROMOTE_TO_MULTI")
 
     if transaction_size is not None:
         args.extend(["-gt", str(transaction_size)])

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -331,14 +331,14 @@ def vector_translate(
                     raise ValueError(f"invalid type in {force_output_geometrytype=}")
         else:
             raise ValueError(f"invalid type for {force_output_geometrytype=}")
-    else:
-        if (
-            input_info.driver == "ESRI Shapefile"
-            and output_info.driver != "ESRI Shapefile"
-        ):
-            # Shapefiles are always reported as singlepart type but can also contain
-            # multiparts geometries, so promote to multi
-            output_geometrytypes.append("PROMOTE_TO_MULTI")
+    elif (
+        not explodecollections
+        and input_info.driver == "ESRI Shapefile"
+        and output_info.driver != "ESRI Shapefile"
+    ):
+        # Shapefiles are always reported as singlepart type but can also contain
+        # multiparts geometries, so promote to multi
+        output_geometrytypes.append("PROMOTE_TO_MULTI")
 
     if transaction_size is not None:
         args.extend(["-gt", str(transaction_size)])

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -133,7 +133,7 @@ class VectorTranslateInfo:
         append: bool = False,
         update: bool = False,
         explodecollections: bool = False,
-        force_output_geometrytype: Union[GeometryType, str, None] = None,
+        force_output_geometrytype: Union[GeometryType, str, Iterable[str], None] = None,
         options: dict = {},
         columns: Optional[Iterable[str]] = None,
         warp: Optional[dict] = None,
@@ -208,7 +208,7 @@ def vector_translate(
     append: bool = False,
     update: bool = False,
     explodecollections: bool = False,
-    force_output_geometrytype: Union[GeometryType, str, None] = None,
+    force_output_geometrytype: Union[GeometryType, str, Iterable[str], None] = None,
     options: dict = {},
     columns: Optional[Iterable[str]] = None,
     warp: Optional[dict] = None,
@@ -319,11 +319,19 @@ def vector_translate(
     if force_output_geometrytype is not None:
         if isinstance(force_output_geometrytype, GeometryType):
             output_geometrytypes.append(force_output_geometrytype.name)
-        else:
+        elif isinstance(force_output_geometrytype, str):
             output_geometrytypes.append(force_output_geometrytype)
-    else:
-        if not explodecollections:
-            output_geometrytypes.append("PROMOTE_TO_MULTI")
+        elif isinstance(force_output_geometrytype, Iterable):
+            for geotype in output_geometrytypes:
+                if isinstance(geotype, GeometryType):
+                    output_geometrytypes.append(geotype.name)
+                elif isinstance(geotype, str):
+                    output_geometrytypes.extend(geotype)
+                else:
+                    raise ValueError(f"invalid type in {force_output_geometrytype=}")
+        else:
+            raise ValueError(f"invalid type for {force_output_geometrytype=}")
+
     if transaction_size is not None:
         args.extend(["-gt", str(transaction_size)])
     if preserve_fid is None:

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -12,7 +12,7 @@ from osgeo import gdal, ogr
 from pygeoops import GeometryType
 
 import geofileops as gfo
-from geofileops import fileops
+from geofileops import _compat, fileops
 
 # Make sure only one instance per process is running
 lock = Lock()
@@ -396,6 +396,10 @@ def vector_translate(
     # Now we can really get to work
     output_ds = None
     try:
+        # Till gdal 3.10 datetime columns can be interpreted wrongly with arrow.
+        if _compat.GDAL_STE_310:
+            config_options["OGR2OGR_USE_ARROW_API"] = False
+
         # Go!
         with set_config_options(config_options):
             # Open input datasource already

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -322,7 +322,7 @@ def vector_translate(
         elif isinstance(force_output_geometrytype, str):
             output_geometrytypes.append(force_output_geometrytype)
         elif isinstance(force_output_geometrytype, Iterable):
-            for geotype in output_geometrytypes:
+            for geotype in force_output_geometrytype:
                 if isinstance(geotype, GeometryType):
                     output_geometrytypes.append(geotype.name)
                 elif isinstance(geotype, str):

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -326,7 +326,7 @@ def vector_translate(
                 if isinstance(geotype, GeometryType):
                     output_geometrytypes.append(geotype.name)
                 elif isinstance(geotype, str):
-                    output_geometrytypes.extend(geotype)
+                    output_geometrytypes.append(geotype)
                 else:
                     raise ValueError(f"invalid type in {force_output_geometrytype=}")
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,10 @@ module = "cloudpickle.*,fiona.*,geopandas.*,matplotlib.*,osgeo.*,osgeo_utils.*,p
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "INFO"
 log_level = "DEBUG"
+addopts = "--disable-warnings"
 
 # Some filters that apply to warnings that can be ignored for any test.
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 log_level = "DEBUG"
+# Write all logging and warnings immediately. Useful for debugging.
+# log_cli = true
+# addopts = "-p no:warnings"
 
 # Some filters that apply to warnings that can be ignored for any test.
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,7 @@ module = "cloudpickle.*,fiona.*,geopandas.*,matplotlib.*,osgeo.*,osgeo_utils.*,p
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-log_cli = true
-log_cli_level = "INFO"
 log_level = "DEBUG"
-addopts = "--disable-warnings"
 
 # Some filters that apply to warnings that can be ignored for any test.
 filterwarnings = [

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -316,9 +316,15 @@ def test_copy_layer_explodecollections(tmp_path, testfile, expected_count):
         ("polygon-parcel", GeometryType.MULTIPOINT),
     ],
 )
+@pytest.mark.filterwarnings(
+    "ignore:.*A geometry of type MULTIPOLYGON is inserted into .*"
+)
 def test_copy_layer_force_output_geometrytype(tmp_path, testfile, force_geometrytype):
     # The conversion is done by ogr, and the "test" is rather written to
-    # explore the behaviour of this ogr functionality
+    # explore the behaviour of this ogr functionality:
+    # Single-part polygons are converted to the destination types, but multipolygons
+    # are kept as they are.
+    # Issue opened for this: https://github.com/OSGeo/gdal/issues/11068
 
     # copy_layer on testfile and force to force_geometrytype
     src = test_helper.get_testfile(testfile)

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -954,7 +954,7 @@ def test_read_file_curve():
     # Test
     read_gdf = gfo.read_file(src)
     assert isinstance(read_gdf, gpd.GeoDataFrame)
-    assert isinstance(read_gdf.geometry[0], sh_geom.MultiPolygon)
+    assert isinstance(read_gdf.geometry[0], sh_geom.Polygon)
 
 
 def test_read_file_invalid_params(tmp_path, engine_setter):

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -1395,6 +1395,7 @@ def test_select_two_layers(tmp_path, suffix, epsg, gridsize):
 
 @pytest.mark.parametrize("suffix", SUFFIXES_GEOOPS)
 @pytest.mark.parametrize("input_nogeom", ["input1", "input2", "both"])
+@pytest.mark.filterwarnings("ignore:.*Field format '' not supported.*")
 def test_select_two_layers_input_without_geom(tmp_path, suffix, input_nogeom):
     # Prepare test file with geom
     input_geom_path = test_helper.get_testfile("polygon-parcel", suffix=suffix)

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -2,7 +2,6 @@
 Tests for operations that are executed using a sql statement on two layers.
 """
 
-import logging
 import math
 import sys
 from contextlib import nullcontext
@@ -1966,7 +1965,6 @@ def test_union(
     keep_fid: bool,
     exp_featurecount: int,
 ):
-    logging.captureWarnings(True)
     if epsg == 4326 and sys.platform in ("darwin", "linux"):
         request.node.add_marker(
             pytest.mark.xfail(

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -413,6 +413,7 @@ def test_export_by_location(
         ("within is False", None, 1000, 0, 15),
     ],
 )
+@pytest.mark.filterwarnings("ignore:.*Field format '' not supported.*")
 def test_export_by_location_area(
     tmp_path,
     query,

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -2,6 +2,7 @@
 Tests for operations that are executed using a sql statement on two layers.
 """
 
+import logging
 import math
 import sys
 from contextlib import nullcontext
@@ -1965,6 +1966,7 @@ def test_union(
     keep_fid: bool,
     exp_featurecount: int,
 ):
+    logging.captureWarnings(True)
     if epsg == 4326 and sys.platform in ("darwin", "linux"):
         request.node.add_marker(
             pytest.mark.xfail(

--- a/tests/test_ogr_util.py
+++ b/tests/test_ogr_util.py
@@ -6,6 +6,7 @@ import os
 
 import pytest
 from osgeo import gdal
+from pygeoops import GeometryType
 
 import geofileops as gfo
 from geofileops._compat import GDAL_GTE_38
@@ -153,7 +154,9 @@ def test_set_config_options():
     [
         (None, "POLYGON"),
         ("MULTIPOLYGON", "MULTIPOLYGON"),
+        (GeometryType.MULTIPOLYGON, "MULTIPOLYGON"),
         (["MULTIPOLYGON"], "MULTIPOLYGON"),
+        ([GeometryType.MULTIPOLYGON], "MULTIPOLYGON"),
         (["PROMOTE_TO_MULTI"], "MULTIPOLYGON"),
     ],
 )

--- a/tests/test_ogr_util.py
+++ b/tests/test_ogr_util.py
@@ -148,6 +148,47 @@ def test_set_config_options():
     assert gdal.GetConfigOption(test3_config_envset) == "test3_new_env_value"
 
 
+@pytest.mark.parametrize(
+    "output_geometrytype, exp_geometrytype",
+    [
+        (None, "POLYGON"),
+        ("MULTIPOLYGON", "MULTIPOLYGON"),
+        (["MULTIPOLYGON"], "MULTIPOLYGON"),
+        (["PROMOTE_TO_MULTI"], "MULTIPOLYGON"),
+    ],
+)
+def test_vector_translate_geometrytype(tmp_path, output_geometrytype, exp_geometrytype):
+    input_path = test_helper.get_testfile(
+        "polygon-parcel", dst_dir=tmp_path, explodecollections=True
+    )
+    output_path = tmp_path / f"output{input_path.suffix}"
+
+    _ogr_util.vector_translate(
+        str(input_path), output_path, force_output_geometrytype=output_geometrytype
+    )
+    output_info = gfo.get_layerinfo(output_path)
+    assert output_info.geometrytypename == exp_geometrytype
+
+
+@pytest.mark.parametrize(
+    "output_geometrytype, exp_error",
+    [
+        (1, "invalid type for"),
+        ([1], "invalid type in"),
+    ],
+)
+def test_vector_translate_geometrytype_error(tmp_path, output_geometrytype, exp_error):
+    input_path = test_helper.get_testfile(
+        "polygon-parcel", dst_dir=tmp_path, explodecollections=True
+    )
+    output_path = tmp_path / f"output{input_path.suffix}"
+
+    with pytest.raises(ValueError, match=exp_error):
+        _ogr_util.vector_translate(
+            str(input_path), output_path, force_output_geometrytype=output_geometrytype
+        )
+
+
 def test_vector_translate_input_nolayer(tmp_path):
     input_path = test_helper.get_testfile("polygon-parcel", dst_dir=tmp_path)
     output_path = tmp_path / f"output{input_path.suffix}"


### PR DESCRIPTION
The reason was that "PROMOTE_TO_MULTI" was always applied if `explodecollection` was `False`.

But apparently a side effect of a `geometrytype` being specified lead to arrow not being used in `gdal.VectorTranslate`... hence removing it lead to arrow being used. But, apparently datetime columns weren't always handled correctly for for e.g. Geopackages by arrow... (https://github.com/OSGeo/gdal/pull/11213).

So, for gdal versions < GDAL 3.11, arrow is now disabled using config option `OGR2OGR_USE_ARROW_API NO`.