### PR TITLE
ENH: avoid integer overflow when gpkg written by geofileops is read from .NET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Add configuration option to only warn on dissolve errors (#561)
 - Add some pre-flight checks when geofileops is imported (#573)
 - Add support for renaming layer with only difference in casing (#593)
+- Avoid integer overflow when gpkg written by geofileops is read from .NET (#612)
 
 ### Bugs fixed
 

--- a/geofileops/util/_sqlite_util.py
+++ b/geofileops/util/_sqlite_util.py
@@ -244,6 +244,8 @@ def get_columns(
                     else:
                         output_geometrytype = GeometryType["GEOMETRY"]
                 columns[columnname] = output_geometrytype.name
+            elif columntype == "INT":
+                columns[columnname] = "INTEGER"
             elif columntype is None or columntype == "":
                 sql = f'SELECT typeof("{columnname}") FROM tmp;'
                 result = conn.execute(sql).fetchall()


### PR DESCRIPTION
Apparently when an sqlite file (e.g. a GPKG) is read from .NET, a column created with datatype "INT" is interpreted as Int32, and a column with type "INTEGER" is interpreted as Int64.

Hence, creating integer columns as "INTEGER" instead of "INT" avoid potential integer overlows in .NET.