### PR TITLE
ENH: support GDAL 3.10.1

### DIFF
--- a/geofileops/_compat.py
+++ b/geofileops/_compat.py
@@ -73,4 +73,4 @@ SHAPELY_GTE_20 = version.parse(shapely.__version__) >= version.parse("2")
 SPATIALITE_GTE_51 = version.parse(sqlite3_spatialite_version) >= version.parse("5.1")
 
 GDAL_GTE_38 = version.parse(gdal.__version__) >= version.parse("3.8")
-GDAL_STE_310 = version.parse(gdal.__version__) <= version.parse("3.10")
+GDAL_ST_311 = version.parse(gdal.__version__) < version.parse("3.11")

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -448,7 +448,7 @@ def vector_translate(
     output_ds = None
     try:
         # Till gdal 3.10 datetime columns can be interpreted wrongly with arrow.
-        if _compat.GDAL_STE_310:
+        if _compat.GDAL_ST_311 and "OGR2OGR_USE_ARROW_API" not in config_options:
             config_options["OGR2OGR_USE_ARROW_API"] = False
 
         # Go!

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -2204,7 +2204,7 @@ def test_union(
     # For text columns, gfo gives None rather than np.nan for missing values.
     for column in exp_gdf.select_dtypes(include="O").columns:
         exp_gdf[column] = exp_gdf[column].replace({np.nan: None})
-    exp_gdf["l1_DATUM"] = pd.to_datetime(exp_gdf["l1_DATUM"])
+    # exp_gdf["l1_DATUM"] = pd.to_datetime(exp_gdf["l1_DATUM"], format="ISO8601")
     if gridsize != 0.0:
         exp_gdf.geometry = shapely.set_precision(exp_gdf.geometry, grid_size=gridsize)
     if explodecollections:

--- a/tests/test_geofileops_twolayers.py
+++ b/tests/test_geofileops_twolayers.py
@@ -2204,7 +2204,6 @@ def test_union(
     # For text columns, gfo gives None rather than np.nan for missing values.
     for column in exp_gdf.select_dtypes(include="O").columns:
         exp_gdf[column] = exp_gdf[column].replace({np.nan: None})
-    # exp_gdf["l1_DATUM"] = pd.to_datetime(exp_gdf["l1_DATUM"], format="ISO8601")
     if gridsize != 0.0:
         exp_gdf.geometry = shapely.set_precision(exp_gdf.geometry, grid_size=gridsize)
     if explodecollections:


### PR DESCRIPTION
Changes:
- don't use arrow for `gdal.VectorTranslate` for all GDAL versions < 3.11
- remove redundant cast to datetime in test that gives an error for gdal > 3.10.0