### PR TITLE
ENH: enable subdividing of linestring layers as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Improve performance of `erase` and `intersection` for very complex input geometries.
   This gives similar improvements for such datasets to `identity`,
   `symmetric_difference` and `union`. (#585, #601, #591)
-- Enable subdividing of linestring layers as well (#)
+- Enable subdividing of linestring layers as well (#614)
 - Add configuration option to only warn on dissolve errors (#561)
 - Add some pre-flight checks when geofileops is imported (#573)
 - Add support for renaming layer with only difference in casing (#593)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Improve performance of `erase` and `intersection` for very complex input geometries.
   This gives similar improvements for such datasets to `identity`,
   `symmetric_difference` and `union`. (#585, #601, #591)
-- only apply subdivide once on each input layer in symmetric_difference
+- Enable subdividing of linestring layers as well (#)
 - Add configuration option to only warn on dissolve errors (#561)
 - Add some pre-flight checks when geofileops is imported (#573)
 - Add support for renaming layer with only difference in casing (#593)

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -1294,9 +1294,9 @@ def _subdivide_layer(
     if subdivide_coords <= 0:
         return None
 
-    # Only subdivide Polygon layers
+    # Never subdivide simple Point layers
     layer_info = gfo.get_layerinfo(path, layer)
-    if layer_info.geometrytype.to_primitivetype != PrimitiveType.POLYGON:
+    if layer_info.geometrytype == GeometryType.POINT:
         return None
 
     # If layer has complex geometries, subdivide them.

--- a/tests/test_geoops_sql.py
+++ b/tests/test_geoops_sql.py
@@ -111,14 +111,18 @@ def test_convert_to_spatialite_based(
 
 
 @pytest.mark.parametrize(
-    "desc, testfile, subdivide_coords, retval_None",
+    "desc, testfile, subdivide_coords, expected_subdivided",
     [
-        ("input not complex", "polygon-zone", 1000, True),
-        ("input poly+complex", "polygon-zone", 1, False),
-        ("input no poly", "linestring-watercourse", 1, True),
+        ("input poly not complex", "polygon-zone", 1000, False),
+        ("input poly complex", "polygon-zone", 1, True),
+        ("input line not complex", "linestring-watercourse", 10_000, False),
+        ("input line complex", "linestring-watercourse", 1, True),
+        ("input point complex", "point", 1, False),
     ],
 )
-def test_subdivide_layer(desc, tmp_path, testfile, subdivide_coords, retval_None):
+def test_subdivide_layer(
+    desc, tmp_path, testfile, subdivide_coords, expected_subdivided: bool
+):
     path = test_helper.get_testfile(testfile)
     result = _geoops_sql._subdivide_layer(
         path=path,
@@ -128,7 +132,7 @@ def test_subdivide_layer(desc, tmp_path, testfile, subdivide_coords, retval_None
         keep_fid=False,
     )
 
-    if retval_None:
-        assert result is None
-    else:
+    if expected_subdivided:
         assert result is not None
+    else:
+        assert result is None


### PR DESCRIPTION
Apparently very large linestring layer also become very slow for intersection,... so subdividing those is necessary as well.