### PR TITLE
CI: add nightly-deps environment to test on

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,10 @@ jobs:
         # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
         extra: ["nomkl"]
         include:
+          - env: nightly-deps
+            os: ubuntu-latest
+            dev: false
+            python: "3.12"
           - env: minimal
             os: ubuntu-latest
             dev: false
@@ -47,11 +51,11 @@ jobs:
           - env: latest-fiona
             os: windows-latest
             dev: false
-            python: "3.11"
+            python: "3.12"
           - env: latest
             os: macos-latest
             dev: false
-            python: "3.11"
+            python: "3.12"
             
     steps:
       - uses: actions/checkout@v4

--- a/ci/envs/nightly-deps.yml
+++ b/ci/envs/nightly-deps.yml
@@ -1,0 +1,26 @@
+name: geofileops-nightly-deps
+channels:
+  - gdal-master
+  - conda-forge
+dependencies:
+  - python
+  - pip
+  # required
+  - cloudpickle
+  - gdal
+  - geopandas-base
+  - libspatialite
+  # - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
+  - numpy
+  - packaging
+  - pandas
+  - psutil
+  - pygeoops
+  - pyogrio
+  - pyproj
+  - shapely
+  # optional
+  - simplification
+  # testing
+  - pytest
+  - pytest-cov

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,5 +1,6 @@
 name: geofileops-dev
 channels:
+  # - gdal-master  # If uncommented, GDAL master will be used for the environment.
   - conda-forge
 dependencies:
   - python =3.10

--- a/geofileops/_compat.py
+++ b/geofileops/_compat.py
@@ -67,14 +67,14 @@ if (
 # Determine the versions of the runtime dependencies
 # gdal.__version__ includes a "dev-..." suffix for master/development versions. This
 # must be dropped for the version checks here.
-GDAL_VERSION = version.parse(gdal.__version__.split("-")[0]).base_version
+GDAL_BASE_VERSION = version.parse(gdal.__version__.split("-")[0]).base_version
 
-GDAL_GTE_38 = version.parse(GDAL_VERSION) >= version.parse("3.8")
+GDAL_GTE_38 = version.parse(GDAL_BASE_VERSION) >= version.parse("3.8")
 GEOPANDAS_GTE_10 = version.parse(gpd.__version__) >= version.parse("1.0")
 PANDAS_GTE_22 = version.parse(pd.__version__) >= version.parse("2.2")
 PYOGRIO_GTE_07 = version.parse(pyogrio.__version__) >= version.parse("0.7")
 SHAPELY_GTE_20 = version.parse(shapely.__version__) >= version.parse("2")
 SPATIALITE_GTE_51 = version.parse(sqlite3_spatialite_version) >= version.parse("5.1")
 
-GDAL_GTE_38 = version.parse(GDAL_VERSION) >= version.parse("3.8")
-GDAL_ST_311 = version.parse(GDAL_VERSION) < version.parse("3.11")
+GDAL_GTE_38 = version.parse(GDAL_BASE_VERSION) >= version.parse("3.8")
+GDAL_ST_311 = version.parse(GDAL_BASE_VERSION) < version.parse("3.11")

--- a/geofileops/_compat.py
+++ b/geofileops/_compat.py
@@ -65,9 +65,9 @@ if (
     )
 
 # Determine the versions of the runtime dependencies
-# gdal.__version__ returns a long version name for master/development versions. The part
-# after the dash must be dropped to avoid version.parse() errors.
-GDAL_VERSION = gdal.__version__.split("-")[0]
+# gdal.__version__ includes a "dev-..." suffix for master/development versions. This
+# must be dropped for the version checks here.
+GDAL_VERSION = version.parse(gdal.__version__.split("-")[0]).base_version
 
 GDAL_GTE_38 = version.parse(GDAL_VERSION) >= version.parse("3.8")
 GEOPANDAS_GTE_10 = version.parse(gpd.__version__) >= version.parse("1.0")

--- a/geofileops/_compat.py
+++ b/geofileops/_compat.py
@@ -65,12 +65,15 @@ if (
     )
 
 # Determine the versions of the runtime dependencies
-GDAL_GTE_38 = version.parse(gdal.__version__) >= version.parse("3.8")
+# gdal.__version__ returns a long version name for master/development versions
+GDAL_VERSION = gdal.VersionInfo("RELEASE_NAME")
+
+GDAL_GTE_38 = version.parse(GDAL_VERSION) >= version.parse("3.8")
 GEOPANDAS_GTE_10 = version.parse(gpd.__version__) >= version.parse("1.0")
 PANDAS_GTE_22 = version.parse(pd.__version__) >= version.parse("2.2")
 PYOGRIO_GTE_07 = version.parse(pyogrio.__version__) >= version.parse("0.7")
 SHAPELY_GTE_20 = version.parse(shapely.__version__) >= version.parse("2")
 SPATIALITE_GTE_51 = version.parse(sqlite3_spatialite_version) >= version.parse("5.1")
 
-GDAL_GTE_38 = version.parse(gdal.__version__) >= version.parse("3.8")
-GDAL_ST_311 = version.parse(gdal.__version__) < version.parse("3.11")
+GDAL_GTE_38 = version.parse(GDAL_VERSION) >= version.parse("3.8")
+GDAL_ST_311 = version.parse(GDAL_VERSION) < version.parse("3.11")

--- a/geofileops/_compat.py
+++ b/geofileops/_compat.py
@@ -65,8 +65,9 @@ if (
     )
 
 # Determine the versions of the runtime dependencies
-# gdal.__version__ returns a long version name for master/development versions
-GDAL_VERSION = gdal.VersionInfo("RELEASE_NAME")
+# gdal.__version__ returns a long version name for master/development versions. The part
+# after the dash must be dropped to avoid version.parse() errors.
+GDAL_VERSION = gdal.__version__.split("-")[0]
 
 GDAL_GTE_38 = version.parse(GDAL_VERSION) >= version.parse("3.8")
 GEOPANDAS_GTE_10 = version.parse(gpd.__version__) >= version.parse("1.0")


### PR DESCRIPTION
Add CI config to test on the gdal "nightly" master version.

GDAL will be installed from the gdal-master conda channel: https://anaconda.org/gdal-master/libgdal-core/files

Activating gdal nightly CI triggered this:
- [x] https://github.com/OSGeo/gdal/issues/11671