### PR TITLE
BUG: When calculating join-nearest, the distance returned is not correct for polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 - Don't convert to multi-part geometries by default in `copy_layer`,... (#570)
 - Add configuration option to only warn on dissolve errors (#561)
 - Add some pre-flight checks when geofileops is imported (#573, #627)
+- When using join_nearest with spatialite version >= 5.1,
+  show ST_distance between the two geometries instead of 
+  the distance between the centroid of the two geometries (#634)
 
 ### Bugs fixed
 

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -2351,7 +2351,11 @@ def join_nearest(
             SELECT layer1.{{input1_geometrycolumn}} as geom
                   {{layer1_columns_prefix_alias_str}}
                   {{layer2_columns_prefix_alias_str}}
-                  ,k.pos, k.distance_m AS distance, k.distance_crs
+                  ,k.pos
+                  ,ST_Distance(
+                    layer1.{{input1_geometrycolumn}}, layer2.{{input2_geometrycolumn}}
+                  ) AS distance
+                  ,k.distance_crs
               FROM "{{input1_layer}}" layer1
               JOIN knn2 k
               JOIN "{{input2_layer}}" layer2 ON layer2.rowid = k.fid


### PR DESCRIPTION
When calculating join-nearest and with spatialite verion >= 5.1 the distance calculated before this PR was not correct for polygons. It was the distance between one polygon and the centroid of the other.