### PR TITLE
BUG: fix `dissolve` with `agg_columns` on sqlite 3.49.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fix `copy_layer` to a gpkg.zip file (#604)
 - Fix GDAL input open options being ignored in `copy_layer` (#632)
 - Fix `missing_ok` parameter in `remove` being ~ignored (#605)
+- Fix `dissolve` with `agg_columns` on sqlite 3.49.1 (#636)
 
 ## 0.9.1 (2024-07-18)
 

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -1470,7 +1470,7 @@ def dissolve(
                             # Prepare column name string.
                             column_str = (
                                 "json_extract(json_data.json_row, "
-                                f'"$.{agg_column["column"]}")'
+                                f"'$.{agg_column['column']}')"
                             )
 
                             # Now put everything together
@@ -1534,7 +1534,7 @@ def dissolve(
                                 {groupby_select_prefixed_str.format(prefix="layer_for_json.")}
                               FROM "{{input_layer}}" layer_for_json
                               CROSS JOIN json_each(
-                                  layer_for_json.__DISSOLVE_TOJSON, "$") json_rows_table
+                                  layer_for_json.__DISSOLVE_TOJSON, '$') json_rows_table
                             ) json_data
                          WHERE 1=1
                             {groupby_filter_str}


### PR DESCRIPTION
Fix `dissolve` with `agg_columns` used on sqlite 3.49.1. throwing error: `no such column: "$" - should this be a string literal in single-quotes?`

Apparently 3.49.1 has become more strict on single versus double quotes used in SQL for json functions. 