### PR TITLE
CI: pin geofileops 0.9.1 to build 3 on tests_installed to avoid old version of sqlite being installed

### DIFF
--- a/.github/workflows/tests_installed.yml
+++ b/.github/workflows/tests_installed.yml
@@ -58,10 +58,6 @@ jobs:
             python=${{ matrix.python }}
             ${{ matrix.install_extra_args }}
 
-      - name: Log
-        run: |
-          micromamba repoquery whoneeds sqlite
-
       - name: Test
         run: |
           pytest --color=yes tests/

--- a/.github/workflows/tests_installed.yml
+++ b/.github/workflows/tests_installed.yml
@@ -40,7 +40,7 @@ jobs:
             # nomkl: openblas instead of mkl saves 600 MB. Linux OK, but 50% slower on Windows and OSX!
             install_extra_args: >-
               nomkl
-              geofileops=0.9.1
+              geofileops=0.9.1=pyhd8ed1ab_3
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests_installed.yml
+++ b/.github/workflows/tests_installed.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Log
         run: |
-          mamba repoquery whoneeds sqlite
+          micromamba repoquery whoneeds sqlite
 
       - name: Test
         run: |

--- a/.github/workflows/tests_installed.yml
+++ b/.github/workflows/tests_installed.yml
@@ -58,6 +58,10 @@ jobs:
             python=${{ matrix.python }}
             ${{ matrix.install_extra_args }}
 
+      - name: Log
+        run: |
+          mamba repoquery whoneeds sqlite
+
       - name: Test
         run: |
           pytest --color=yes tests/


### PR DESCRIPTION
Resolves #645