### PR TITLE
ENH: in add_column, don't add column if update expression is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,7 @@
 - Enable "CURVE" geometrytype files to be processed in the general file and
   layer operations (#558)
 - Don't convert to multi-part geometries by default in `copy_layer`,... (#570)
-- In `add_column`, when update fails, rollback column being added if file type supports
-  transactions (#650)
+- In `add_column`, don't add column if update expression is invalid (#650)
 - Add configuration option to only warn on dissolve errors (#561)
 - Add some pre-flight checks when geofileops is imported (#573, #627)
 - For `select_two_layers`, add the `gpkg_ogr_contents` table + fill out extents in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - Enable "CURVE" geometrytype files to be processed in the general file and
   layer operations (#558)
 - Don't convert to multi-part geometries by default in `copy_layer`,... (#570)
+- In `add_column`, when update fails, rollback column being added if file type supports
+  transactions (#650)
 - Add configuration option to only warn on dissolve errors (#561)
 - Add some pre-flight checks when geofileops is imported (#573, #627)
 - For `select_two_layers`, add the `gpkg_ogr_contents` table + fill out extents in the

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -172,6 +172,9 @@ def StartTransaction(datasource: gdal.Dataset) -> bool:
     Args:
         datasource (gdal.Dataset): the datasource to start the transaction on.
 
+    Raises:
+        ValueError: if datasource is None.
+
     Returns:
         bool: True if the transaction was started successfully.
     """
@@ -179,47 +182,52 @@ def StartTransaction(datasource: gdal.Dataset) -> bool:
         raise ValueError("datasource is None")
 
     try:
-        datasource.StartTransaction()
+        if datasource.TestCapability(ogr.ODsCTransactions):
+            datasource.StartTransaction()
     except Exception:
         return False
 
     return True
 
 
-def CommitTransaction(datasource: gdal.Dataset) -> bool:
+def CommitTransaction(datasource: Optional[gdal.Dataset]) -> bool:
     """Commits a transaction on an open datasource.
 
     Args:
-        datasource (gdal.Dataset): the datasource to commit the transaction on.
+        datasource (gdal.Dataset): the datasource to commit the transaction on. If None,
+            no commit is executed.
 
     Returns:
         bool: True if the transaction was committed successfully.
     """
     if datasource is None:
-        raise ValueError("datasource is None")
+        return False
 
     try:
-        datasource.CommitTransaction()
+        if datasource.TestCapability(ogr.ODsCTransactions):
+            datasource.CommitTransaction()
     except Exception:
         return False
 
     return True
 
 
-def RollbackTransaction(datasource: gdal.Dataset) -> bool:
+def RollbackTransaction(datasource: Optional[gdal.Dataset]) -> bool:
     """Rolls back a transaction on an open datasource.
 
     Args:
-        datasource (gdal.Dataset): the datasource to roll back the transaction on.
+        datasource (gdal.Dataset): the datasource to roll back the transaction on. If
+            None, no rollback is executed.
 
     Returns:
         bool: True if the transaction was rolled back successfully.
     """
     if datasource is None:
-        raise ValueError("datasource is None")
+        return False
 
     try:
-        datasource.RollbackTransaction()
+        if datasource.TestCapability(ogr.ODsCTransactions):
+            datasource.RollbackTransaction()
     except Exception:
         return False
 

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -181,11 +181,8 @@ def StartTransaction(datasource: gdal.Dataset) -> bool:
     if datasource is None:
         raise ValueError("datasource is None")
 
-    try:
-        if datasource.TestCapability(ogr.ODsCTransactions):
-            datasource.StartTransaction()
-    except Exception:
-        return False
+    if datasource.TestCapability(ogr.ODsCTransactions):
+        datasource.StartTransaction()
 
     return True
 
@@ -203,11 +200,8 @@ def CommitTransaction(datasource: Optional[gdal.Dataset]) -> bool:
     if datasource is None:
         return False
 
-    try:
-        if datasource.TestCapability(ogr.ODsCTransactions):
-            datasource.CommitTransaction()
-    except Exception:
-        return False
+    if datasource.TestCapability(ogr.ODsCTransactions):
+        datasource.CommitTransaction()
 
     return True
 
@@ -225,11 +219,8 @@ def RollbackTransaction(datasource: Optional[gdal.Dataset]) -> bool:
     if datasource is None:
         return False
 
-    try:
-        if datasource.TestCapability(ogr.ODsCTransactions):
-            datasource.RollbackTransaction()
-    except Exception:
-        return False
+    if datasource.TestCapability(ogr.ODsCTransactions):
+        datasource.RollbackTransaction()
 
     return True
 

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -176,7 +176,7 @@ def StartTransaction(datasource: gdal.Dataset) -> bool:
         bool: True if the transaction was started successfully.
     """
     if datasource is None:
-        return False
+        raise ValueError("datasource is None")
 
     try:
         datasource.StartTransaction()
@@ -196,7 +196,7 @@ def CommitTransaction(datasource: gdal.Dataset) -> bool:
         bool: True if the transaction was committed successfully.
     """
     if datasource is None:
-        return False
+        raise ValueError("datasource is None")
 
     try:
         datasource.CommitTransaction()
@@ -216,7 +216,7 @@ def RollbackTransaction(datasource: gdal.Dataset) -> bool:
         bool: True if the transaction was rolled back successfully.
     """
     if datasource is None:
-        return False
+        raise ValueError("datasource is None")
 
     try:
         datasource.RollbackTransaction()

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -166,6 +166,66 @@ def read_cpl_log(path: Path) -> tuple[list[str], list[str]]:
     return (lines_cleaned, lines_error)
 
 
+def StartTransaction(datasource: gdal.Dataset) -> bool:
+    """Starts a transaction on an open datasource.
+
+    Args:
+        datasource (gdal.Dataset): the datasource to start the transaction on.
+
+    Returns:
+        bool: True if the transaction was started successfully.
+    """
+    if datasource is None:
+        return False
+
+    try:
+        datasource.StartTransaction()
+    except Exception:
+        return False
+
+    return True
+
+
+def CommitTransaction(datasource: gdal.Dataset) -> bool:
+    """Commits a transaction on an open datasource.
+
+    Args:
+        datasource (gdal.Dataset): the datasource to commit the transaction on.
+
+    Returns:
+        bool: True if the transaction was committed successfully.
+    """
+    if datasource is None:
+        return False
+
+    try:
+        datasource.CommitTransaction()
+    except Exception:
+        return False
+
+    return True
+
+
+def RollbackTransaction(datasource: gdal.Dataset) -> bool:
+    """Rolls back a transaction on an open datasource.
+
+    Args:
+        datasource (gdal.Dataset): the datasource to roll back the transaction on.
+
+    Returns:
+        bool: True if the transaction was rolled back successfully.
+    """
+    if datasource is None:
+        return False
+
+    try:
+        datasource.RollbackTransaction()
+    except Exception:
+        return False
+
+    return True
+
+
 class VectorTranslateInfo:
     def __init__(
         self,

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -123,6 +123,24 @@ def test_add_column_gpkg(tmp_path):
     assert gdf["HFDTLT"][0] == "5"
 
 
+@pytest.mark.parametrize("suffix", [".gpkg", ".shp"])
+def test_add_column_update_error(tmp_path, suffix):
+    """Test that when the update gives an error, the column is not added."""
+    test_path = test_helper.get_testfile(
+        "polygon-parcel", dst_dir=tmp_path, suffix=suffix
+    )
+
+    # Add a column with an invalid expression
+    with pytest.raises(RuntimeError, match="add_column error for"):
+        gfo.add_column(
+            test_path, name="ERROR_COLUMN", type="TEXT", expression="invalid_expression"
+        )
+
+    # The column should not be added, as GPKG supports transactions
+    info = gfo.get_layerinfo(test_path)
+    assert "ERROR_COLUMN" not in list(info.columns)
+
+
 def test_append_different_layer(tmp_path):
     # Prepare test data
     src_path = test_helper.get_testfile("polygon-parcel", dst_dir=tmp_path)

--- a/tests/test_ogr_util.py
+++ b/tests/test_ogr_util.py
@@ -149,15 +149,17 @@ def test_set_config_options():
     assert gdal.GetConfigOption(test3_config_envset) == "test3_new_env_value"
 
 
-def test_transactions():
+def test_StartTransaction_None():
     with pytest.raises(Exception, match="datasource is None"):
         _ogr_util.StartTransaction(None)
 
-    with pytest.raises(Exception, match="datasource is None"):
-        _ogr_util.CommitTransaction(None)
 
-    with pytest.raises(Exception, match="datasource is None"):
-        _ogr_util.RollbackTransaction(None)
+def test_CommitTransaction_None():
+    assert not _ogr_util.CommitTransaction(None)
+
+
+def test_RollbackTransaction_None():
+    assert not _ogr_util.RollbackTransaction(None)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ogr_util.py
+++ b/tests/test_ogr_util.py
@@ -149,6 +149,17 @@ def test_set_config_options():
     assert gdal.GetConfigOption(test3_config_envset) == "test3_new_env_value"
 
 
+def test_transactions():
+    with pytest.raises(Exception, match="datasource is None"):
+        _ogr_util.StartTransaction(None)
+
+    with pytest.raises(Exception, match="datasource is None"):
+        _ogr_util.CommitTransaction(None)
+
+    with pytest.raises(Exception, match="datasource is None"):
+        _ogr_util.RollbackTransaction(None)
+
+
 @pytest.mark.parametrize(
     "output_geometrytype, exp_geometrytype",
     [


### PR DESCRIPTION
If adding the column succeeds but the update fails, the output files is in a state that is not ideal: when the `add_column` is ran again, the column won't be "fixed". It would be better that this is transactional: if the update fails, the add should be rolled back well.

This PR adds using transactions for this case.

Mind: transactions are not supported for all file types! E.g. 
- for .gpkg this will work fine.
- for .shp the column will still stay added as transactions are not supported.