### PR TITLE
MAINT: make pyogrio 0.7 the minimal version

### DIFF
--- a/ci/envs/latest-fiona.yml
+++ b/ci/envs/latest-fiona.yml
@@ -15,7 +15,7 @@ dependencies:
   - pandas
   - psutil
   - pygeoops >=0.4,<0.5
-  - pyogrio >=0.5
+  - pyogrio >=0.7
   - pyproj
   - shapely >=2,<2.1
   # optional

--- a/ci/envs/latest.yml
+++ b/ci/envs/latest.yml
@@ -15,7 +15,7 @@ dependencies:
   - pandas
   - psutil
   - pygeoops >=0.4,<0.5
-  - pyogrio >=0.5
+  - pyogrio >=0.7
   - pyproj
   - shapely >=2,<2.1
   # optional

--- a/ci/envs/readthedocs.yml
+++ b/ci/envs/readthedocs.yml
@@ -13,10 +13,10 @@ dependencies:
   - packaging
   - pandas
   - psutil
-  - pygeoops>=0.4,<0.5
-  - pyogrio>=0.5
+  - pygeoops >=0.4,<0.5
+  - pyogrio >=0.7
   - pyproj
-  - shapely>=2,<2.1
+  - shapely >=2,<2.1
   # optional
   - simplification
   # docs

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -16,7 +16,7 @@ dependencies:
   - pandas
   - psutil
   - pygeoops >=0.4,<0.5
-  - pyogrio >=0.5
+  - pyogrio >=0.7
   - pyproj
   - shapely >=2,<2.1
   # optional

--- a/geofileops/__init__.py
+++ b/geofileops/__init__.py
@@ -1,11 +1,17 @@
 """Library to make spatial operations on large geo files fast(er) and easy."""
 
+import multiprocessing
 import os
+import warnings
 from pathlib import Path
 
 # Import geopandas here so the warning about pygeos <> shapely2 is given, but set
 # USE_PYGEOS to avoid further warnings
 import geopandas._compat as gpd_compat
+import pyogrio
+
+from geofileops import _compat
+from geofileops.util import _ogr_util
 
 if hasattr(gpd_compat, "USE_PYGEOS"):
     if gpd_compat.USE_PYGEOS:
@@ -27,3 +33,55 @@ def _get_version():
 
 
 __version__ = _get_version()
+
+
+# Do some pre-flight checks to ensure mandatory runtime dependencies are available.
+def _pyogrio_spatialite_version_info() -> dict[str, str]:
+    test_path = Path(__file__).resolve().parent / "util/test.gpkg"
+
+    sql = "SELECT spatialite_version(), geos_version()"
+    result = pyogrio.read_dataframe(test_path, sql=sql)
+    spatialite_version = result.iloc[0, 0]
+    geos_version = result.iloc[0, 1]
+
+    if not spatialite_version:  # pragma: no cover
+        warnings.warn(
+            "empty pyogrio spatialite version: probably a geofileops dependency was "
+            "not installed correctly: check the installation instructions in the "
+            "geofileops docs.",
+            stacklevel=1,
+        )
+    if not geos_version:  # pragma: no cover
+        warnings.warn(
+            "empty pyogrio spatialite GEOS version: probably a geofileops dependency "
+            "was not installed correctly: check the installation instructions in the "
+            "geofileops docs.",
+            stacklevel=1,
+        )
+
+    versions = {
+        "spatialite_version": spatialite_version,
+        "geos_version": geos_version,
+    }
+    return versions
+
+
+# Check the spatialite versions of the dependencies only in the main process
+if multiprocessing.parent_process() is None:
+    pyogrio_spatialite_version_info = _pyogrio_spatialite_version_info()
+
+    gdal_spatialite_version_info = _ogr_util.spatialite_version_info()
+
+    # Check that the spatialite versions are the same
+    pyogrio_spatialite_version = pyogrio_spatialite_version_info["spatialite_version"]
+
+    gdal_spatialite_version = gdal_spatialite_version_info["spatialite_version"]
+    if (
+        pyogrio_spatialite_version != _compat.sqlite3_spatialite_version
+        or pyogrio_spatialite_version != gdal_spatialite_version
+    ):  # pragma: no cover
+        warnings.warn(
+            f"different spatialite versions loaded: {pyogrio_spatialite_version=} vs "
+            f"{_compat.sqlite3_spatialite_version=} vs {gdal_spatialite_version=}",
+            stacklevel=1,
+        )

--- a/geofileops/_compat.py
+++ b/geofileops/_compat.py
@@ -56,7 +56,6 @@ GDAL_ST_311 = version.parse(GDAL_BASE_VERSION) < version.parse("3.11")
 
 GEOPANDAS_GTE_10 = version.parse(gpd.__version__) >= version.parse("1.0")
 PANDAS_GTE_22 = version.parse(pd.__version__) >= version.parse("2.2")
-PYOGRIO_GTE_07 = version.parse(pyogrio.__version__) >= version.parse("0.7")
 SHAPELY_GTE_20 = version.parse(shapely.__version__) >= version.parse("2")
 
 sqlite3_spatialite_version_info = _sqlite_util.spatialite_version_info()

--- a/geofileops/_compat.py
+++ b/geofileops/_compat.py
@@ -1,51 +1,14 @@
 """Module with compatibility and dependency availability checks."""
 
-import multiprocessing
-import warnings
-from pathlib import Path
-
 import geopandas as gpd
 import pandas as pd
-import pyogrio
 import shapely
 from osgeo import gdal
 from packaging import version
 
-from geofileops.util import _ogr_util, _sqlite_util
+from geofileops.util import _sqlite_util
 
 gdal.UseExceptions()
-
-
-# Do some pre-flight checks to ensure mandatory runtime dependencies are available.
-def _pyogrio_spatialite_version_info() -> dict[str, str]:
-    test_path = Path(__file__).resolve().parent / "util/test.gpkg"
-
-    sql = "SELECT spatialite_version(), geos_version()"
-    result = pyogrio.read_dataframe(test_path, sql=sql)
-    spatialite_version = result.iloc[0, 0]
-    geos_version = result.iloc[0, 1]
-
-    if not spatialite_version:  # pragma: no cover
-        warnings.warn(
-            "empty pyogrio spatialite version: probably a geofileops dependency was "
-            "not installed correctly: check the installation instructions in the "
-            "geofileops docs.",
-            stacklevel=1,
-        )
-    if not geos_version:  # pragma: no cover
-        warnings.warn(
-            "empty pyogrio spatialite GEOS version: probably a geofileops dependency "
-            "was not installed correctly: check the installation instructions in the "
-            "geofileops docs.",
-            stacklevel=1,
-        )
-
-    versions = {
-        "spatialite_version": spatialite_version,
-        "geos_version": geos_version,
-    }
-    return versions
-
 
 # Determine the versions of the runtime dependencies
 # gdal.__version__ includes a "dev-..." suffix for master/development versions. This
@@ -61,24 +24,3 @@ SHAPELY_GTE_20 = version.parse(shapely.__version__) >= version.parse("2")
 sqlite3_spatialite_version_info = _sqlite_util.spatialite_version_info()
 sqlite3_spatialite_version = sqlite3_spatialite_version_info["spatialite_version"]
 SPATIALITE_GTE_51 = version.parse(sqlite3_spatialite_version) >= version.parse("5.1")
-
-
-# If running in the main process, check the spatialite versions of the dependencies
-if multiprocessing.parent_process() is None:
-    pyogrio_spatialite_version_info = _pyogrio_spatialite_version_info()
-
-    gdal_spatialite_version_info = _ogr_util.spatialite_version_info()
-
-    # Check that the spatialite versions are the same
-    pyogrio_spatialite_version = pyogrio_spatialite_version_info["spatialite_version"]
-
-    gdal_spatialite_version = gdal_spatialite_version_info["spatialite_version"]
-    if (
-        pyogrio_spatialite_version != sqlite3_spatialite_version
-        or pyogrio_spatialite_version != gdal_spatialite_version
-    ):  # pragma: no cover
-        warnings.warn(
-            f"different spatialite versions loaded: {pyogrio_spatialite_version=} vs "
-            f"{sqlite3_spatialite_version=} vs {gdal_spatialite_version=}",
-            stacklevel=1,
-        )

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -29,7 +29,6 @@ from osgeo import gdal, ogr
 from pandas.api.types import is_integer_dtype
 from pygeoops import GeometryType, PrimitiveType  # noqa: F401
 
-from geofileops._compat import PYOGRIO_GTE_07
 from geofileops.helpers._configoptions_helper import ConfigOptions
 from geofileops.util import (
     _geofileinfo,
@@ -1767,22 +1766,6 @@ def to_file(
         force_multitype = True
 
     engine = ConfigOptions.io_engine
-
-    # pyogrio < 0.7 doesn't support writing without geometry, so in that case use fiona.
-    if not PYOGRIO_GTE_07:
-        if not isinstance(gdf, gpd.GeoDataFrame) or (
-            isinstance(gdf, gpd.GeoDataFrame) and "geometry" not in gdf.columns
-        ):
-            # Give a clear error if fiona isn't installed.
-            try:
-                import fiona  # noqa: F401
-            except ImportError as ex:  # pragma: no cover
-                raise RuntimeError(
-                    "to write dataframes without geometry either pyogrio >= 0.7 "
-                    "(recommended) or fiona needs to be installed."
-                ) from ex
-
-            engine = "fiona"
 
     # Write file with the correct engine
     if engine == "pyogrio":

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "pandas>=1.5",
         "psutil",
         "pygeoops>=0.4,<0.5",
-        "pyogrio",
+        "pyogrio>=0.7",
         "pyproj",
         "shapely>=2,<2.1",
     ],


### PR DESCRIPTION
make pyogrio 0.7 the minimal version
and:
- remove code that becomes obsolete due to this...
- move the pre-flight check code for the spatialite versions to __init__.py because it gave circular references in _compat.py