### PR TITLE
ENH: use forkserver to create worker processes on linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Deprecations and compatibility notes
 
-- processes are being spawned using "spawn" also on linux now. This solves risks of
-  deadlocks and the corresponding warning for that. Consequence is that also on linux
+- worker processes are now being created using "forkserver" on linux. This solves risks
+  of deadlocks and the corresponding warning for that. Consequence is that also on linux
   the `if __name__ == "__main__":` construct needs to be used in scripts. Some more info
   can be found in the geofileops FAQ (#675).
 - `erase` was renamed to `difference`, as most other open source applications/libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Deprecations and compatibility notes
 
+- processes are being spawned using "spawn" also on linux now. This solves risks of
+  deadlocks and the corresponding warning for that. Consequence is that also on linux
+  the `if __name__ == "__main__":` construct needs to be used in scripts. Some more info
+  can be found in the geofileops FAQ (#675).
 - `erase` was renamed to `difference`, as most other open source applications/libraries
   use this terminology. `erase` just keeps existing for backwards compatibility for now,
   but a warning is shown that it might be removed in the (distant) future. (#595)

--- a/geofileops/helpers/_general_helper.py
+++ b/geofileops/helpers/_general_helper.py
@@ -1,4 +1,4 @@
-import os
+"""General helper functions, specific for geofileops."""
 
 from geofileops.helpers._configoptions_helper import ConfigOptions
 

--- a/geofileops/helpers/_general_helper.py
+++ b/geofileops/helpers/_general_helper.py
@@ -10,12 +10,7 @@ def use_threads(input_layer_featurecount: int) -> bool:
     elif worker_type == "process":
         return False
 
-    """
-    if os.name != "nt":
-        return False"
-    """
-
-    # Processing in threads is 2x faster for small datasets on Windows
+    # Processing in threads is 2x faster for small datasets
     if input_layer_featurecount <= 100:
         return True
 

--- a/geofileops/helpers/_general_helper.py
+++ b/geofileops/helpers/_general_helper.py
@@ -10,8 +10,10 @@ def use_threads(input_layer_featurecount: int) -> bool:
     elif worker_type == "process":
         return False
 
+    """
     if os.name != "nt":
-        return False
+        return False"
+    """
 
     # Processing in threads is 2x faster for small datasets on Windows
     if input_layer_featurecount <= 100:

--- a/geofileops/util/_processing_util.py
+++ b/geofileops/util/_processing_util.py
@@ -45,9 +45,7 @@ class PooledExecutorFactory:
                 max_workers=self.max_workers, initializer=self.initializer
             )
         else:
-            if self.mp_context is None and not (
-                os.name == "nt" and os.name == "darwin"
-            ):
+            if self.mp_context is None and os.name not in {"nt", "darwin"}:
                 # On linux, use "forkserver" to avoid risks to deadlocks
                 self.mp_context = multiprocessing.get_context("forkserver")
             self.pool = futures.ProcessPoolExecutor(

--- a/geofileops/util/_processing_util.py
+++ b/geofileops/util/_processing_util.py
@@ -45,8 +45,11 @@ class PooledExecutorFactory:
                 max_workers=self.max_workers, initializer=self.initializer
             )
         else:
-            if self.mp_context is None:
-                self.mp_context = multiprocessing.get_context("spawn")
+            if self.mp_context is None and not (
+                os.name == "nt" and os.name == "darwin"
+            ):
+                # On linux, use "forkserver" to avoid risks to deadlocks
+                self.mp_context = multiprocessing.get_context("forkserver")
             self.pool = futures.ProcessPoolExecutor(
                 max_workers=self.max_workers,
                 initializer=self.initializer,

--- a/tests/test_general_helper.py
+++ b/tests/test_general_helper.py
@@ -15,11 +15,8 @@ def test_use_threads(worker_type, input_layer_featurecount):
         expected = False
     elif worker_type == "thread":
         expected = True
-    elif os.name == "nt":
-        if input_layer_featurecount <= 100:
-            expected = True
-        else:
-            expected = False
+    elif input_layer_featurecount <= 100:
+        expected = True
     else:
         expected = False
 

--- a/tests/test_general_helper.py
+++ b/tests/test_general_helper.py
@@ -1,4 +1,4 @@
-import os
+"""Tests for the general_helper module."""
 
 import pytest
 

--- a/tests/test_geofileops_singlelayer.py
+++ b/tests/test_geofileops_singlelayer.py
@@ -150,8 +150,9 @@ def basic_combinations_to_test(
 
 
 @pytest.mark.parametrize("suffix_input", SUFFIXES_GEOOPS_INPUT)
+@pytest.mark.parametrize("worker_type", ["thread", "process"])
 @pytest.mark.parametrize("geoops_module", GEOOPS_MODULES)
-def test_buffer(tmp_path, suffix_input, geoops_module):
+def test_buffer(tmp_path, suffix_input, worker_type, geoops_module):
     """Buffer minimal test."""
     # Prepare test data
     input_path = test_helper.get_testfile("polygon-parcel", suffix=suffix_input)
@@ -161,14 +162,15 @@ def test_buffer(tmp_path, suffix_input, geoops_module):
     # Now run test
     output_path = tmp_path / "output.gpkg"
     set_geoops_module(geoops_module)
-    geoops.buffer(
-        input_path=input_path,
-        output_path=output_path,
-        distance=1,
-        nb_parallel=2,
-        keep_empty_geoms=True,
-        batchsize=batchsize,
-    )
+    with _general_util.TempEnv({"GFO_WORKER_TYPE": worker_type}):
+        geoops.buffer(
+            input_path=input_path,
+            output_path=output_path,
+            distance=1,
+            nb_parallel=2,
+            keep_empty_geoms=True,
+            batchsize=batchsize,
+        )
 
     # Now check if the output file is correctly created
     assert output_path.exists()


### PR DESCRIPTION
Use "forkserver" to create worker processes on linux.

This solves the following deprecationwarning: `This process (pid=2361) is multi-threaded, use of fork() may lead to deadlocks in the child.`

"forkserver" will become the default on [python 3.14](https://docs.python.org/3.14/whatsnew/3.14.html#concurrent-futures).

Note: this does have a significant performance impact in some use cases. E.g. running the tests (a lot of operations on small files that are forced to run in 2 processes) took:
- 1.5 minutes using fork
- 5.5 minutes using forkserver
- 7.5 minutes using spawn
- 1.5 minutes using threads (which is now the case: if input files < 100 rows)