### PR TITLE
BUG: create_spatial_index with force_rebuild gives an error on gpkg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Use `ST_Equals` and add priority feature to `delete_duplicate_geometries` (#638)
 - Avoid integer overflow when gpkg written by geofileops is read from .NET (#612)
 - Speed up processing many small files, mainly on windows:
-    - reduce calls to `gdal.OpenEx` (#622, #625)
+    - reduce calls to `gdal.OpenEx` (#622, #625, #677)
     - improvements in sqlite3 code for 2 layer operations: start transactions
       explicitly, remove obsolete GPKG triggers, use a :memory: temp file where possible
       (#626, #628, #630)

--- a/tests/general_file_layer_operations/test_indexes.py
+++ b/tests/general_file_layer_operations/test_indexes.py
@@ -156,12 +156,18 @@ def test_create_spatial_index_invalid_params():
 
 
 @pytest.mark.parametrize("suffix", [s for s in SUFFIXES_FILEOPS if s != ".csv"])
-def test_has_spatial_index(suffix):
-    src = test_helper.get_testfile("polygon-parcel", suffix=suffix)
+def test_has_spatial_index(tmp_path, suffix):
+    src = test_helper.get_testfile("polygon-parcel", suffix=suffix, dst_dir=tmp_path)
 
     # Test
     has_spatial_index = gfo.has_spatial_index(src)
-    assert has_spatial_index
+    if GeofileInfo(src).default_spatial_index:
+        assert has_spatial_index
+    else:
+        # File format that doesn't have a spatial index by default
+        assert not has_spatial_index
+        gfo.create_spatial_index(src)
+        assert gfo.has_spatial_index(src)
 
 
 def test_has_spatial_index_datasource():

--- a/tests/general_file_layer_operations/test_indexes.py
+++ b/tests/general_file_layer_operations/test_indexes.py
@@ -1,0 +1,203 @@
+"""Tests regarding spatial indexes in/on data sources."""
+
+import pytest
+from osgeo import gdal
+
+import geofileops as gfo
+from geofileops import fileops
+from geofileops.util._geofileinfo import GeofileInfo
+from tests import test_helper
+from tests.test_helper import SUFFIXES_FILEOPS
+
+
+@pytest.mark.parametrize("suffix", [s for s in SUFFIXES_FILEOPS if s != ".csv"])
+def test_create_spatial_index(tmp_path, suffix):
+    test_path = test_helper.get_testfile(
+        "polygon-parcel", dst_dir=tmp_path, suffix=suffix
+    )
+    layer = gfo.get_only_layer(test_path)
+    default_spatial_index = GeofileInfo(test_path).default_spatial_index
+
+    # Check if spatial index present
+    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
+    assert has_spatial_index is default_spatial_index
+
+    # Remove spatial index
+    gfo.remove_spatial_index(path=test_path, layer=layer)
+    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
+    assert has_spatial_index is False
+
+    # Create spatial index
+    gfo.create_spatial_index(path=test_path, layer=layer)
+    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
+    assert has_spatial_index is True
+
+    # Spatial index if it already exists by default gives error
+    with pytest.raises(Exception, match="spatial index already exists"):
+        gfo.create_spatial_index(path=test_path, layer=layer)
+    gfo.create_spatial_index(path=test_path, layer=layer, exist_ok=True)
+
+
+@pytest.mark.parametrize("suffix", [s for s in SUFFIXES_FILEOPS if s != ".csv"])
+def test_create_spatial_index_force_rebuild(tmp_path, suffix):
+    test_path = test_helper.get_testfile(
+        "polygon-parcel", dst_dir=tmp_path, suffix=suffix
+    )
+    if suffix == ".shp":
+        # Shapefile doesn't have a spatial index by default
+        gfo.create_spatial_index(path=test_path, exist_ok=True)
+        # Test of rebuild on shp can be checked on the files created/changed
+        qix_path = test_path.with_suffix(".qix")
+        qix_modified_time_orig = qix_path.stat().st_mtime
+        gfo.create_spatial_index(path=test_path, exist_ok=True)
+        assert qix_path.stat().st_mtime == qix_modified_time_orig
+        gfo.create_spatial_index(path=test_path, force_rebuild=True)
+        assert qix_path.stat().st_mtime > qix_modified_time_orig
+
+    elif suffix == ".gpkg":
+        gfo.create_spatial_index(path=test_path, exist_ok=True)
+        has_spatial_index = gfo.has_spatial_index(path=test_path)
+        assert has_spatial_index is True
+        gfo.create_spatial_index(path=test_path, force_rebuild=True)
+        has_spatial_index = gfo.has_spatial_index(path=test_path)
+        assert has_spatial_index is True
+
+
+def test_create_spatial_index_gpkg_zip(tmp_path):
+    """Spatial index tests are specific for .gpkg.zip as it is read-only."""
+    # Test cases where the input file has an index
+    # --------------------------------------------
+    test_path = test_helper.get_testfile(
+        "polygon-parcel", dst_dir=tmp_path, suffix=".gpkg.zip"
+    )
+    layer = gfo.get_only_layer(test_path)
+
+    # Check if spatial index present
+    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
+    assert has_spatial_index is True
+
+    # Removing spatial index in not supported as .gpkg.zip is read-only
+    with pytest.raises(RuntimeError, match="remove_spatial_index error"):
+        gfo.remove_spatial_index(path=test_path, layer=layer)
+
+    # Create spatial index is supported with `exist_ok=True`
+    gfo.create_spatial_index(path=test_path, layer=layer, exist_ok=True)
+
+    # If no `exist_ok=True` is specified, error
+    with pytest.raises(RuntimeError, match="spatial index already exists"):
+        gfo.create_spatial_index(path=test_path, layer=layer)
+
+    # If  `force_rebuild=True` is specified, error
+    with pytest.raises(
+        RuntimeError, match="create_spatial_index not supported for .gpkg.zip files"
+    ):
+        gfo.create_spatial_index(path=test_path, layer=layer, force_rebuild=True)
+
+    # Test cases where the input file does not have an index
+    # ------------------------------------------------------
+    # Prepare .gpkg file without spatial index
+    test_path = test_helper.get_testfile(
+        "polygon-parcel", dst_dir=tmp_path, suffix=".gpkg"
+    )
+    layer = gfo.get_only_layer(test_path)
+    gfo.remove_spatial_index(path=test_path, layer=layer)
+    assert not gfo.has_spatial_index(path=test_path, layer=layer)
+    test_zip_path = tmp_path / f"{test_path.name}.zip"
+    fileops._zip(test_path, test_zip_path)
+    assert not gfo.has_spatial_index(path=test_path, layer=layer)
+
+    with pytest.raises(
+        RuntimeError, match="create_spatial_index not supported for .gpkg.zip files"
+    ):
+        gfo.create_spatial_index(path=test_zip_path, layer=layer)
+
+
+def test_create_spatial_index_unsupported(tmp_path):
+    # Prepare test data
+    suffix = ".geojson"
+    path = tmp_path / f"unsupported_type{suffix}"
+    geojson_data = """{
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [125.6, 10.1]
+            },
+            "properties": {
+                "name": "Dinagat Islands"
+            }
+        }
+    """
+    with open(path, "w") as file:
+        file.write(geojson_data)
+
+    # Test
+    with pytest.raises(
+        ValueError, match="create_spatial_index not supported for GeoJSON"
+    ):
+        _ = gfo.create_spatial_index(path, path.stem)
+
+    with pytest.raises(ValueError, match="has_spatial_index not supported for GeoJSON"):
+        _ = gfo.has_spatial_index(path, path.stem)
+
+    with pytest.raises(
+        ValueError, match="remove_spatial_index not supported for GeoJSON"
+    ):
+        _ = gfo.remove_spatial_index(path, path.stem)
+
+
+def test_create_spatial_index_invalid_params():
+    path = test_helper.get_testfile("polygon-parcel")
+
+    # Test invalid parameters
+    with pytest.raises(
+        ValueError, match="exist_ok and force_rebuild can't both be True"
+    ):
+        _ = gfo.create_spatial_index(path=path, exist_ok=True, force_rebuild=True)
+
+
+def test_has_spatial_index():
+    src = test_helper.get_testfile("polygon-parcel")
+
+    # Test
+    has_spatial_index = gfo.has_spatial_index(src)
+    assert has_spatial_index
+
+
+def test_has_spatial_index_datasource():
+    src = test_helper.get_testfile("polygon-parcel")
+
+    # Test
+    datasource = gdal.OpenEx(str(src), gdal.OF_VECTOR)
+    has_spatial_index = gfo.has_spatial_index(src, datasource=datasource)
+    assert has_spatial_index
+
+    assert datasource is not None
+    datasource = None
+
+
+def test_remove_spatial_index(tmp_path):
+    # Prepare test data
+    src = test_helper.get_testfile("polygon-parcel", dst_dir=tmp_path)
+    gfo.create_spatial_index(src, exist_ok=True)
+    assert gfo.has_spatial_index(src)
+
+    # Remove spatial index and check result
+    gfo.remove_spatial_index(src)
+    assert not gfo.has_spatial_index(src)
+
+
+def test_remove_spatial_index_datasource(tmp_path):
+    # Prepare test data
+    src = test_helper.get_testfile("polygon-parcel", dst_dir=tmp_path)
+    gfo.create_spatial_index(src, exist_ok=True)
+    assert gfo.has_spatial_index(src)
+
+    # Remove spatial index and check result
+    datasource = gdal.OpenEx(str(src), gdal.OF_VECTOR | gdal.OF_UPDATE)
+    gfo.remove_spatial_index(src, datasource=datasource)
+
+    # Check result
+    assert not gfo.has_spatial_index(src)
+    # Datasource should not be closed by has_spatial_index
+    assert datasource is not None
+    datasource = None

--- a/tests/general_file_layer_operations/test_indexes.py
+++ b/tests/general_file_layer_operations/test_indexes.py
@@ -155,8 +155,9 @@ def test_create_spatial_index_invalid_params():
         _ = gfo.create_spatial_index(path=path, exist_ok=True, force_rebuild=True)
 
 
-def test_has_spatial_index():
-    src = test_helper.get_testfile("polygon-parcel")
+@pytest.mark.parametrize("suffix", [s for s in SUFFIXES_FILEOPS if s != ".csv"])
+def test_has_spatial_index(suffix):
+    src = test_helper.get_testfile("polygon-parcel", suffix=suffix)
 
     # Test
     has_spatial_index = gfo.has_spatial_index(src)
@@ -173,6 +174,27 @@ def test_has_spatial_index_datasource():
 
     assert datasource is not None
     datasource = None
+
+
+def test_has_spatial_index_no_geom(tmp_path):
+    """A geofile without geometry column never has a spatial index."""
+    # Prepare test data
+    src = test_helper.get_testfile("polygon-parcel", suffix=".csv")
+    test_path = tmp_path / "test_file.dbf"
+    gfo.copy_layer(src, test_path)
+
+    # Test
+    has_spatial_index = gfo.has_spatial_index(test_path)
+    assert not has_spatial_index
+
+
+@pytest.mark.parametrize("suffix", [".csv"])
+def test_has_spatial_index_unsupported(suffix):
+    src = test_helper.get_testfile("polygon-parcel", suffix=suffix)
+
+    # Test
+    with pytest.raises(ValueError, match="has_spatial_index not supported for CSV"):
+        _ = gfo.has_spatial_index(src)
 
 
 def test_remove_spatial_index(tmp_path):

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -945,6 +945,151 @@ def test_copy_error(tmp_path):
         gfo.copy(src, dst)
 
 
+@pytest.mark.parametrize("suffix", [s for s in SUFFIXES_FILEOPS if s != ".csv"])
+def test_create_spatial_index(tmp_path, suffix):
+    test_path = test_helper.get_testfile(
+        "polygon-parcel", dst_dir=tmp_path, suffix=suffix
+    )
+    layer = gfo.get_only_layer(test_path)
+    default_spatial_index = GeofileInfo(test_path).default_spatial_index
+
+    # Check if spatial index present
+    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
+    assert has_spatial_index is default_spatial_index
+
+    # Remove spatial index
+    gfo.remove_spatial_index(path=test_path, layer=layer)
+    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
+    assert has_spatial_index is False
+
+    # Create spatial index
+    gfo.create_spatial_index(path=test_path, layer=layer)
+    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
+    assert has_spatial_index is True
+
+    # Spatial index if it already exists by default gives error
+    with pytest.raises(Exception, match="spatial index already exists"):
+        gfo.create_spatial_index(path=test_path, layer=layer)
+    gfo.create_spatial_index(path=test_path, layer=layer, exist_ok=True)
+
+
+@pytest.mark.parametrize("suffix", [s for s in SUFFIXES_FILEOPS if s != ".csv"])
+def test_create_spatial_index_force_rebuild(tmp_path, suffix):
+    test_path = test_helper.get_testfile(
+        "polygon-parcel", dst_dir=tmp_path, suffix=suffix
+    )
+    if suffix == ".shp":
+        # Shapefile doesn't have a spatial index by default
+        gfo.create_spatial_index(path=test_path, exist_ok=True)
+        # Test of rebuild on shp can be checked on the files created/changed
+        qix_path = test_path.with_suffix(".qix")
+        qix_modified_time_orig = qix_path.stat().st_mtime
+        gfo.create_spatial_index(path=test_path, exist_ok=True)
+        assert qix_path.stat().st_mtime == qix_modified_time_orig
+        gfo.create_spatial_index(path=test_path, force_rebuild=True)
+        assert qix_path.stat().st_mtime > qix_modified_time_orig
+
+    elif suffix == ".gpkg":
+        gfo.create_spatial_index(path=test_path, exist_ok=True)
+        has_spatial_index = gfo.has_spatial_index(path=test_path)
+        assert has_spatial_index is True
+        gfo.create_spatial_index(path=test_path, force_rebuild=True)
+        has_spatial_index = gfo.has_spatial_index(path=test_path)
+        assert has_spatial_index is True
+
+
+def test_create_spatial_index_gpkg_zip(tmp_path):
+    """Spatial index tests are specific for .gpkg.zip as it is read-only."""
+    # Test cases where the input file has an index
+    # --------------------------------------------
+    test_path = test_helper.get_testfile(
+        "polygon-parcel", dst_dir=tmp_path, suffix=".gpkg.zip"
+    )
+    layer = gfo.get_only_layer(test_path)
+
+    # Check if spatial index present
+    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
+    assert has_spatial_index is True
+
+    # Removing spatial index in not supported as .gpkg.zip is read-only
+    with pytest.raises(RuntimeError, match="remove_spatial_index error"):
+        gfo.remove_spatial_index(path=test_path, layer=layer)
+
+    # Create spatial index is supported with `exist_ok=True`
+    gfo.create_spatial_index(path=test_path, layer=layer, exist_ok=True)
+
+    # If no `exist_ok=True` is specified, error
+    with pytest.raises(RuntimeError, match="spatial index already exists"):
+        gfo.create_spatial_index(path=test_path, layer=layer)
+
+    # If  `force_rebuild=True` is specified, error
+    with pytest.raises(
+        RuntimeError, match="create_spatial_index not supported for .gpkg.zip files"
+    ):
+        gfo.create_spatial_index(path=test_path, layer=layer, force_rebuild=True)
+
+    # Test cases where the input file does not have an index
+    # ------------------------------------------------------
+    # Prepare .gpkg file without spatial index
+    test_path = test_helper.get_testfile(
+        "polygon-parcel", dst_dir=tmp_path, suffix=".gpkg"
+    )
+    layer = gfo.get_only_layer(test_path)
+    gfo.remove_spatial_index(path=test_path, layer=layer)
+    assert not gfo.has_spatial_index(path=test_path, layer=layer)
+    test_zip_path = tmp_path / f"{test_path.name}.zip"
+    fileops._zip(test_path, test_zip_path)
+    assert not gfo.has_spatial_index(path=test_path, layer=layer)
+
+    with pytest.raises(
+        RuntimeError, match="create_spatial_index not supported for .gpkg.zip files"
+    ):
+        gfo.create_spatial_index(path=test_zip_path, layer=layer)
+
+
+def test_create_spatial_index_unsupported(tmp_path):
+    # Prepare test data
+    suffix = ".geojson"
+    path = tmp_path / f"unsupported_type{suffix}"
+    geojson_data = """{
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [125.6, 10.1]
+            },
+            "properties": {
+                "name": "Dinagat Islands"
+            }
+        }
+    """
+    with open(path, "w") as file:
+        file.write(geojson_data)
+
+    # Test
+    with pytest.raises(
+        ValueError, match="create_spatial_index not supported for GeoJSON"
+    ):
+        _ = gfo.create_spatial_index(path, path.stem)
+
+    with pytest.raises(ValueError, match="has_spatial_index not supported for GeoJSON"):
+        _ = gfo.has_spatial_index(path, path.stem)
+
+    with pytest.raises(
+        ValueError, match="remove_spatial_index not supported for GeoJSON"
+    ):
+        _ = gfo.remove_spatial_index(path, path.stem)
+
+
+def test_create_spatial_index_invalid_params():
+    path = test_helper.get_testfile("polygon-parcel")
+
+    # Test invalid parameters
+    with pytest.raises(
+        ValueError, match="exist_ok and force_rebuild can't both be True"
+    ):
+        _ = gfo.create_spatial_index(path=path, exist_ok=True, force_rebuild=True)
+
+
 @pytest.mark.parametrize("suffix", SUFFIXES_FILEOPS)
 def test_drop_column(tmp_path, suffix):
     # Prepare test data
@@ -1110,6 +1255,26 @@ def test_get_layerinfo(suffix, dimensions):
 
     assert len(layerinfo.columns) == 11
     assert layerinfo.columns["OIDN"].gdal_type == "Integer64"
+
+
+def test_get_layerinfo_datasource():
+    """Test get_layerinfo with datasource as input.
+
+    The datasource should not be closed after the function call.
+    """
+    # Prepare test data
+    src = test_helper.get_testfile("polygon-parcel")
+
+    # Test
+    datasource = gdal.OpenEx(str(src), gdal.OF_VECTOR)
+    layerinfo = gfo.get_layerinfo(src, datasource=datasource)
+
+    # Check results
+    assert layerinfo.featurecount == 48
+
+    # The datasource should still be open
+    assert datasource is not None
+    datasource = None
 
 
 @pytest.mark.xfail
@@ -1774,142 +1939,6 @@ def test_fill_out_sql_placeholders_errors(layer, sql_stmt, error):
         fileops._fill_out_sql_placeholders(
             path, layer=layer, sql_stmt=sql_stmt, columns=None
         )
-
-
-@pytest.mark.parametrize("suffix", [s for s in SUFFIXES_FILEOPS if s != ".csv"])
-def test_spatial_index(tmp_path, suffix):
-    test_path = test_helper.get_testfile(
-        "polygon-parcel", dst_dir=tmp_path, suffix=suffix
-    )
-    layer = gfo.get_only_layer(test_path)
-    default_spatial_index = GeofileInfo(test_path).default_spatial_index
-
-    # Check if spatial index present
-    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
-    assert has_spatial_index is default_spatial_index
-
-    # Remove spatial index
-    gfo.remove_spatial_index(path=test_path, layer=layer)
-    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
-    assert has_spatial_index is False
-
-    # Create spatial index
-    gfo.create_spatial_index(path=test_path, layer=layer)
-    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
-    assert has_spatial_index is True
-
-    # Spatial index if it already exists by default gives error
-    with pytest.raises(Exception, match="spatial index already exists"):
-        gfo.create_spatial_index(path=test_path, layer=layer)
-    gfo.create_spatial_index(path=test_path, layer=layer, exist_ok=True)
-
-    # Test of rebuild only easy on shapefile
-    if suffix == ".shp":
-        qix_path = test_path.with_suffix(".qix")
-        qix_modified_time_orig = qix_path.stat().st_mtime
-        gfo.create_spatial_index(path=test_path, layer=layer, exist_ok=True)
-        assert qix_path.stat().st_mtime == qix_modified_time_orig
-        gfo.create_spatial_index(path=test_path, layer=layer, force_rebuild=True)
-        assert qix_path.stat().st_mtime > qix_modified_time_orig
-    elif suffix == ".gpkg":
-        gfo.create_spatial_index(path=test_path, layer=layer, exist_ok=True)
-        has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
-        assert has_spatial_index is True
-        gfo.create_spatial_index(path=test_path, layer=layer, force_rebuild=True)
-        has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
-        assert has_spatial_index is True
-
-
-def test_spatial_index_gpkg_zip(tmp_path):
-    """Spatial index tests are specific for .gpkg.zip as it is read-only."""
-    # Test cases where the input file has an index
-    # --------------------------------------------
-    test_path = test_helper.get_testfile(
-        "polygon-parcel", dst_dir=tmp_path, suffix=".gpkg.zip"
-    )
-    layer = gfo.get_only_layer(test_path)
-
-    # Check if spatial index present
-    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
-    assert has_spatial_index is True
-
-    # Removing spatial index in not supported as .gpkg.zip is read-only
-    with pytest.raises(RuntimeError, match="remove_spatial_index error"):
-        gfo.remove_spatial_index(path=test_path, layer=layer)
-
-    # Create spatial index is supported with `exist_ok=True`
-    gfo.create_spatial_index(path=test_path, layer=layer, exist_ok=True)
-
-    # If no `exist_ok=True` is specified, error
-    with pytest.raises(RuntimeError, match="spatial index already exists"):
-        gfo.create_spatial_index(path=test_path, layer=layer)
-
-    # If  `force_rebuild=True` is specified, error
-    with pytest.raises(
-        RuntimeError, match="create_spatial_index not supported for .gpkg.zip files"
-    ):
-        gfo.create_spatial_index(path=test_path, layer=layer, force_rebuild=True)
-
-    # Test cases where the input file does not have an index
-    # ------------------------------------------------------
-    # Prepare .gpkg file without spatial index
-    test_path = test_helper.get_testfile(
-        "polygon-parcel", dst_dir=tmp_path, suffix=".gpkg"
-    )
-    layer = gfo.get_only_layer(test_path)
-    gfo.remove_spatial_index(path=test_path, layer=layer)
-    assert not gfo.has_spatial_index(path=test_path, layer=layer)
-    test_zip_path = tmp_path / f"{test_path.name}.zip"
-    fileops._zip(test_path, test_zip_path)
-    assert not gfo.has_spatial_index(path=test_path, layer=layer)
-
-    with pytest.raises(
-        RuntimeError, match="create_spatial_index not supported for .gpkg.zip files"
-    ):
-        gfo.create_spatial_index(path=test_zip_path, layer=layer)
-
-
-def test_spatial_index_unsupported(tmp_path):
-    # Prepare test data
-    suffix = ".geojson"
-    path = tmp_path / f"unsupported_type{suffix}"
-    geojson_data = """{
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [125.6, 10.1]
-            },
-            "properties": {
-                "name": "Dinagat Islands"
-            }
-        }
-    """
-    with open(path, "w") as file:
-        file.write(geojson_data)
-
-    # Test
-    with pytest.raises(
-        ValueError, match="create_spatial_index not supported for GeoJSON"
-    ):
-        _ = gfo.create_spatial_index(path, path.stem)
-
-    with pytest.raises(ValueError, match="has_spatial_index not supported for GeoJSON"):
-        _ = gfo.has_spatial_index(path, path.stem)
-
-    with pytest.raises(
-        ValueError, match="remove_spatial_index not supported for GeoJSON"
-    ):
-        _ = gfo.remove_spatial_index(path, path.stem)
-
-
-def test_create_spatial_index_invalid_params():
-    path = test_helper.get_testfile("polygon-parcel")
-
-    # Test invalid parameters
-    with pytest.raises(
-        ValueError, match="exist_ok and force_rebuild can't both be True"
-    ):
-        _ = gfo.create_spatial_index(path=path, exist_ok=True, force_rebuild=True)
 
 
 @pytest.mark.parametrize("suffix", SUFFIXES_FILEOPS_EXT)

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -1811,6 +1811,13 @@ def test_spatial_index(tmp_path, suffix):
         assert qix_path.stat().st_mtime == qix_modified_time_orig
         gfo.create_spatial_index(path=test_path, layer=layer, force_rebuild=True)
         assert qix_path.stat().st_mtime > qix_modified_time_orig
+    elif suffix == ".gpkg":
+        gfo.create_spatial_index(path=test_path, layer=layer, exist_ok=True)
+        has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
+        assert has_spatial_index is True
+        gfo.create_spatial_index(path=test_path, layer=layer, force_rebuild=True)
+        has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
+        assert has_spatial_index is True
 
 
 def test_spatial_index_gpkg_zip(tmp_path):

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -1400,6 +1400,26 @@ def test_get_only_layer_vsi():
     assert layer == "poly"
 
 
+def test_has_spatial_index():
+    src = test_helper.get_testfile("polygon-parcel")
+
+    # Test
+    has_spatial_index = gfo.has_spatial_index(src)
+    assert has_spatial_index
+
+
+def test_has_spatial_index_datasource():
+    src = test_helper.get_testfile("polygon-parcel")
+
+    # Test
+    datasource = gdal.OpenEx(str(src), gdal.OF_VECTOR)
+    has_spatial_index = gfo.has_spatial_index(src, datasource=datasource)
+    assert has_spatial_index
+
+    assert datasource is not None
+    datasource = None
+
+
 @pytest.mark.filterwarnings(
     "ignore: is_geofile is deprecated and will be removed in a future version"
 )
@@ -2485,7 +2505,35 @@ def test_remove(tmp_path, suffix):
 
     # Remove and check result
     gfo.remove(str(src))
-    assert src.exists() is False
+    assert not src.exists()
+
+
+def test_remove_spatial_index(tmp_path):
+    # Prepare test data
+    src = test_helper.get_testfile("polygon-parcel", dst_dir=tmp_path)
+    gfo.create_spatial_index(src, exist_ok=True)
+    assert gfo.has_spatial_index(src)
+
+    # Remove spatial index and check result
+    gfo.remove_spatial_index(src)
+    assert not gfo.has_spatial_index(src)
+
+
+def test_remove_spatial_index_datasource(tmp_path):
+    # Prepare test data
+    src = test_helper.get_testfile("polygon-parcel", dst_dir=tmp_path)
+    gfo.create_spatial_index(src, exist_ok=True)
+    assert gfo.has_spatial_index(src)
+
+    # Remove spatial index and check result
+    datasource = gdal.OpenEx(str(src), gdal.OF_VECTOR | gdal.OF_UPDATE)
+    gfo.remove_spatial_index(src, datasource=datasource)
+
+    # Check result
+    assert not gfo.has_spatial_index(src)
+    # Datasource should not be closed by has_spatial_index
+    assert datasource is not None
+    datasource = None
 
 
 def test_launder_columns():

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -18,7 +18,6 @@ from pygeoops import GeometryType
 import geofileops as gfo
 from geofileops import fileops
 from geofileops.util import _geofileinfo, _geopath_util, _geoseries_util
-from geofileops.util._geofileinfo import GeofileInfo
 from tests import test_helper
 from tests.test_helper import (
     SUFFIXES_FILEOPS,
@@ -945,151 +944,6 @@ def test_copy_error(tmp_path):
         gfo.copy(src, dst)
 
 
-@pytest.mark.parametrize("suffix", [s for s in SUFFIXES_FILEOPS if s != ".csv"])
-def test_create_spatial_index(tmp_path, suffix):
-    test_path = test_helper.get_testfile(
-        "polygon-parcel", dst_dir=tmp_path, suffix=suffix
-    )
-    layer = gfo.get_only_layer(test_path)
-    default_spatial_index = GeofileInfo(test_path).default_spatial_index
-
-    # Check if spatial index present
-    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
-    assert has_spatial_index is default_spatial_index
-
-    # Remove spatial index
-    gfo.remove_spatial_index(path=test_path, layer=layer)
-    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
-    assert has_spatial_index is False
-
-    # Create spatial index
-    gfo.create_spatial_index(path=test_path, layer=layer)
-    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
-    assert has_spatial_index is True
-
-    # Spatial index if it already exists by default gives error
-    with pytest.raises(Exception, match="spatial index already exists"):
-        gfo.create_spatial_index(path=test_path, layer=layer)
-    gfo.create_spatial_index(path=test_path, layer=layer, exist_ok=True)
-
-
-@pytest.mark.parametrize("suffix", [s for s in SUFFIXES_FILEOPS if s != ".csv"])
-def test_create_spatial_index_force_rebuild(tmp_path, suffix):
-    test_path = test_helper.get_testfile(
-        "polygon-parcel", dst_dir=tmp_path, suffix=suffix
-    )
-    if suffix == ".shp":
-        # Shapefile doesn't have a spatial index by default
-        gfo.create_spatial_index(path=test_path, exist_ok=True)
-        # Test of rebuild on shp can be checked on the files created/changed
-        qix_path = test_path.with_suffix(".qix")
-        qix_modified_time_orig = qix_path.stat().st_mtime
-        gfo.create_spatial_index(path=test_path, exist_ok=True)
-        assert qix_path.stat().st_mtime == qix_modified_time_orig
-        gfo.create_spatial_index(path=test_path, force_rebuild=True)
-        assert qix_path.stat().st_mtime > qix_modified_time_orig
-
-    elif suffix == ".gpkg":
-        gfo.create_spatial_index(path=test_path, exist_ok=True)
-        has_spatial_index = gfo.has_spatial_index(path=test_path)
-        assert has_spatial_index is True
-        gfo.create_spatial_index(path=test_path, force_rebuild=True)
-        has_spatial_index = gfo.has_spatial_index(path=test_path)
-        assert has_spatial_index is True
-
-
-def test_create_spatial_index_gpkg_zip(tmp_path):
-    """Spatial index tests are specific for .gpkg.zip as it is read-only."""
-    # Test cases where the input file has an index
-    # --------------------------------------------
-    test_path = test_helper.get_testfile(
-        "polygon-parcel", dst_dir=tmp_path, suffix=".gpkg.zip"
-    )
-    layer = gfo.get_only_layer(test_path)
-
-    # Check if spatial index present
-    has_spatial_index = gfo.has_spatial_index(path=test_path, layer=layer)
-    assert has_spatial_index is True
-
-    # Removing spatial index in not supported as .gpkg.zip is read-only
-    with pytest.raises(RuntimeError, match="remove_spatial_index error"):
-        gfo.remove_spatial_index(path=test_path, layer=layer)
-
-    # Create spatial index is supported with `exist_ok=True`
-    gfo.create_spatial_index(path=test_path, layer=layer, exist_ok=True)
-
-    # If no `exist_ok=True` is specified, error
-    with pytest.raises(RuntimeError, match="spatial index already exists"):
-        gfo.create_spatial_index(path=test_path, layer=layer)
-
-    # If  `force_rebuild=True` is specified, error
-    with pytest.raises(
-        RuntimeError, match="create_spatial_index not supported for .gpkg.zip files"
-    ):
-        gfo.create_spatial_index(path=test_path, layer=layer, force_rebuild=True)
-
-    # Test cases where the input file does not have an index
-    # ------------------------------------------------------
-    # Prepare .gpkg file without spatial index
-    test_path = test_helper.get_testfile(
-        "polygon-parcel", dst_dir=tmp_path, suffix=".gpkg"
-    )
-    layer = gfo.get_only_layer(test_path)
-    gfo.remove_spatial_index(path=test_path, layer=layer)
-    assert not gfo.has_spatial_index(path=test_path, layer=layer)
-    test_zip_path = tmp_path / f"{test_path.name}.zip"
-    fileops._zip(test_path, test_zip_path)
-    assert not gfo.has_spatial_index(path=test_path, layer=layer)
-
-    with pytest.raises(
-        RuntimeError, match="create_spatial_index not supported for .gpkg.zip files"
-    ):
-        gfo.create_spatial_index(path=test_zip_path, layer=layer)
-
-
-def test_create_spatial_index_unsupported(tmp_path):
-    # Prepare test data
-    suffix = ".geojson"
-    path = tmp_path / f"unsupported_type{suffix}"
-    geojson_data = """{
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [125.6, 10.1]
-            },
-            "properties": {
-                "name": "Dinagat Islands"
-            }
-        }
-    """
-    with open(path, "w") as file:
-        file.write(geojson_data)
-
-    # Test
-    with pytest.raises(
-        ValueError, match="create_spatial_index not supported for GeoJSON"
-    ):
-        _ = gfo.create_spatial_index(path, path.stem)
-
-    with pytest.raises(ValueError, match="has_spatial_index not supported for GeoJSON"):
-        _ = gfo.has_spatial_index(path, path.stem)
-
-    with pytest.raises(
-        ValueError, match="remove_spatial_index not supported for GeoJSON"
-    ):
-        _ = gfo.remove_spatial_index(path, path.stem)
-
-
-def test_create_spatial_index_invalid_params():
-    path = test_helper.get_testfile("polygon-parcel")
-
-    # Test invalid parameters
-    with pytest.raises(
-        ValueError, match="exist_ok and force_rebuild can't both be True"
-    ):
-        _ = gfo.create_spatial_index(path=path, exist_ok=True, force_rebuild=True)
-
-
 @pytest.mark.parametrize("suffix", SUFFIXES_FILEOPS)
 def test_drop_column(tmp_path, suffix):
     # Prepare test data
@@ -1398,26 +1252,6 @@ def test_get_only_layer_vsi():
     # Test
     layer = gfo.get_only_layer(src)
     assert layer == "poly"
-
-
-def test_has_spatial_index():
-    src = test_helper.get_testfile("polygon-parcel")
-
-    # Test
-    has_spatial_index = gfo.has_spatial_index(src)
-    assert has_spatial_index
-
-
-def test_has_spatial_index_datasource():
-    src = test_helper.get_testfile("polygon-parcel")
-
-    # Test
-    datasource = gdal.OpenEx(str(src), gdal.OF_VECTOR)
-    has_spatial_index = gfo.has_spatial_index(src, datasource=datasource)
-    assert has_spatial_index
-
-    assert datasource is not None
-    datasource = None
 
 
 @pytest.mark.filterwarnings(
@@ -2506,34 +2340,6 @@ def test_remove(tmp_path, suffix):
     # Remove and check result
     gfo.remove(str(src))
     assert not src.exists()
-
-
-def test_remove_spatial_index(tmp_path):
-    # Prepare test data
-    src = test_helper.get_testfile("polygon-parcel", dst_dir=tmp_path)
-    gfo.create_spatial_index(src, exist_ok=True)
-    assert gfo.has_spatial_index(src)
-
-    # Remove spatial index and check result
-    gfo.remove_spatial_index(src)
-    assert not gfo.has_spatial_index(src)
-
-
-def test_remove_spatial_index_datasource(tmp_path):
-    # Prepare test data
-    src = test_helper.get_testfile("polygon-parcel", dst_dir=tmp_path)
-    gfo.create_spatial_index(src, exist_ok=True)
-    assert gfo.has_spatial_index(src)
-
-    # Remove spatial index and check result
-    datasource = gdal.OpenEx(str(src), gdal.OF_VECTOR | gdal.OF_UPDATE)
-    gfo.remove_spatial_index(src, datasource=datasource)
-
-    # Check result
-    assert not gfo.has_spatial_index(src)
-    # Datasource should not be closed by has_spatial_index
-    assert datasource is not None
-    datasource = None
 
 
 def test_launder_columns():

--- a/tests/test_geofile.py
+++ b/tests/test_geofile.py
@@ -1834,7 +1834,7 @@ def test_spatial_index_gpkg_zip(tmp_path):
     assert has_spatial_index is True
 
     # Removing spatial index in not supported as .gpkg.zip is read-only
-    with pytest.raises(ValueError, match="remove_spatial_index not supported for"):
+    with pytest.raises(RuntimeError, match="remove_spatial_index error"):
         gfo.remove_spatial_index(path=test_path, layer=layer)
 
     # Create spatial index is supported with `exist_ok=True`


### PR DESCRIPTION
Changes:
- Add test on + fix error in `create_spatial_index` with `force_rebuild=True` introduced in #625 
- Simplify/refactor changes introduced in #625
- Improve test coverage on spatial index functions + put them in seperate module

Bug doesn't need to be mentioned explicitly in changelog as it was never released...