### PR TITLE
DEPR: deprecate the GFO_IO_ENGINE configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Deprecations and compatibility notes
 
-- Add warning when GFO_IO_ENGINE is used with engine "fiona" that this is deprecated and
-  will be removed/ignored in a future version (#688)
+- Add warning when the GFO_IO_ENGINE configuration option is used with engine "fiona"
+  that this is deprecated and will be removed/ignored in a future version (#688)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.10.1 (yyyy-mm-dd)
 
+### Deprecations and compatibility notes
+
+- Add warnings when the "fiona" GFO_IO_ENGINE is used that this is deprecated and will
+  be removed in a future version (#)
+
 ### Improvements
 
 - Don't pin maximum versions of dependencies for e.g. geopandas, shapely, pyogrio (#685)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Deprecations and compatibility notes
 
-- Add warnings when the "fiona" GFO_IO_ENGINE is used that this is deprecated and will
-  be removed in a future version (#)
+- Add warning when GFO_IO_ENGINE is used with engine "fiona" that this is deprecated and
+  will be removed/ignored in a future version (#688)
 
 ### Improvements
 
@@ -13,8 +13,8 @@
 
 ### Bugs fixed
 
-- Fix error in `create_spatial_index` on a read-only file even if index exists
-  already (#686)
+- Don't throw error when running `create_spatial_index` on a read-only file if the index
+  exists already (#686)
 
 ## 0.10.0 (2025-03-26)
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -45,8 +45,9 @@ Runtime configuration options
 GeofileOps supports some runtime configuration options that can be set using environment
 variables:
 
-- `GFO_IO_ENGINE`: the IO engine to use when reading and writing GeoDataFrames. Valid
-  options are "pyogrio" and "fiona". Defaults to "pyogrio".
+- `GFO_IO_ENGINE`: the configuration option is deprecated and will be ignored in a
+  future version of geofileops. The IO engine to use when reading and writing
+  GeoDataFrames. Valid options are "pyogrio" and "fiona". Defaults to "pyogrio".
 - `GFO_ON_DATA_ERROR`: the action to take when a data error occurs while processing a
   tile during dissolve. Data errors are e.g. invalid geometries encountered/created
   during processing. Valid options are "raise" and "warn". The "warn" option will lead

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -1429,7 +1429,17 @@ def _read_file_base_fiona(
     fid_as_index: bool = False,
     **kwargs,
 ) -> pd.DataFrame | gpd.GeoDataFrame:
-    """Reads a file to a pandas Dataframe using fiona."""
+    """Reads a file to a pandas Dataframe using fiona.
+
+    The "fiona" IO engine is deprecated and will be removed in the future.
+    """
+    warnings.warn(
+        "The geofileops configuration option GFO_IO_ENGINE is deprecated. In a future "
+        "version it will be ignored and the pyogrio engine will always be used.",
+        FutureWarning,
+        stacklevel=4,
+    )
+
     if ignore_geometry and columns == []:
         return pd.DataFrame()
     if sql_stmt is not None:
@@ -1837,7 +1847,16 @@ def _to_file_fiona(
     create_spatial_index: bool | None = None,
     **kwargs,
 ):
-    """Writes a pandas dataframe to file using fiona."""
+    """Writes a pandas dataframe to file using fiona.
+
+    The "fiona" IO engine is deprecated and will be removed in the future.
+    """
+    warnings.warn(
+        "The geofileops configuration option GFO_IO_ENGINE is deprecated. In a future "
+        "version it will be ignored and the pyogrio engine will always be used.",
+        FutureWarning,
+        stacklevel=3,
+    )
     if append and not _vsi_exists(path):
         append = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ filterwarnings = [
     "ignore: Normalized/laundered field name",
     "ignore: Non-conformant content for record 0 in column",
     "ignore: Non-conformant content for record 1 in column",
+    "ignore: The geofileops configuration option GFO_IO_ENGINE is deprecated",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
 Add a warning when the GFO_IO_ENGINE configuration option is used with engine "fiona" that this is deprecated and
  will be removed/ignored in a future version.