### PR TITLE
BUG: on some input files spatial operations take significant time even though output exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Don't throw error when running `create_spatial_index` on a read-only file if the index
   exists already (#686)
 - Fix `join_by_location` when using "contains" (#694)
+- On some input files `dissolve` takes significant time even though output exists and
+  `force=False` (#696)
 
 ## 0.10.0 (2025-03-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@
 - Don't throw error when running `create_spatial_index` on a read-only file if the index
   exists already (#686)
 - Fix `join_by_location` when using "contains" (#694)
-- On some input files `dissolve` takes significant time even though output exists and
-  `force=False` (#696)
+- On some input files spatial operations take significant time even though output exists
+  and `force=False` (#696)
 
 ## 0.10.0 (2025-03-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@
 - Don't throw error when running `create_spatial_index` on a read-only file if the index
   exists already (#686)
 - Fix `join_by_location` when using "contains" (#694)
-- On some input files spatial operations take significant time even though output exists
-  and `force=False` (#696)
+- Fix that on some input files spatial operations take significant time, even though
+  the output exists already and `force=False` (#696)
 
 ## 0.10.0 (2025-03-26)
 

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -95,11 +95,10 @@ def dissolve_within_distance(
         * :func:`dissolve`: dissolve the input layer
 
     """
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
-
     input_path = Path(input_path)
     output_path = Path(output_path)
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
 
     start_time = datetime.now()
     operation_name = "dissolve_within_distance"

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -95,6 +95,9 @@ def dissolve_within_distance(
         * :func:`dissolve`: dissolve the input layer
 
     """
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     input_path = Path(input_path)
     output_path = Path(output_path)
 
@@ -102,10 +105,6 @@ def dissolve_within_distance(
     operation_name = "dissolve_within_distance"
     logger = logging.getLogger(f"geofileops.{operation_name}")
     nb_steps = 9
-
-    # Already check here if it is useful to continue
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
 
     tempdir = _io_util.create_tempdir(f"geofileops/{operation_name}")
     try:

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -751,10 +751,10 @@ def _apply_geooperation_to_layer(
     if _io_util.output_exists(path=output_path, remove_if_exists=force):
         return
 
-    if not input_path.exists():
-        raise FileNotFoundError(f"{operation_name}: input_path not found: {input_path}")
     if input_path == output_path:
         raise ValueError(f"{operation_name}: output_path must not equal input_path")
+    if not input_path.exists():
+        raise FileNotFoundError(f"{operation_name}: input_path not found: {input_path}")
 
     if not isinstance(input_layer, LayerInfo):
         input_layer = gfo.get_layerinfo(input_path, input_layer)
@@ -1132,10 +1132,10 @@ def dissolve(
 
     if groupby_columns is not None and len(list(groupby_columns)) == 0:
         raise ValueError("groupby_columns=[] is not supported. Use None.")
-    if not input_path.exists():
-        raise FileNotFoundError(f"input_path not found: {input_path}")
     if input_path == output_path:
         raise ValueError("output_path must not equal input_path")
+    if not input_path.exists():
+        raise FileNotFoundError(f"input_path not found: {input_path}")
 
     if not isinstance(input_layer, LayerInfo):
         input_layer = gfo.get_layerinfo(input_path, input_layer)

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -564,6 +564,9 @@ def makevalid(
     batchsize: int = -1,
     force: bool = False,
 ):
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     # Determine if collapsed parts need to be kept after makevalid or not
     keep_collapsed = True
     if force_output_geometrytype is None:
@@ -745,12 +748,14 @@ def _apply_geooperation_to_layer(
     logger = logging.getLogger(f"geofileops.{operation_name}")
 
     # Check input parameters...
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     if not input_path.exists():
         raise FileNotFoundError(f"{operation_name}: input_path not found: {input_path}")
     if input_path == output_path:
         raise ValueError(f"{operation_name}: output_path must not equal input_path")
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
+
     if not isinstance(input_layer, LayerInfo):
         input_layer = gfo.get_layerinfo(input_path, input_layer)
     if output_layer is None:
@@ -1121,7 +1126,10 @@ def dissolve(
     operation_name = f"{operation_prefix}dissolve"
     logger = logging.getLogger(f"geofileops.{operation_name}")
 
-    # Basic checks on input parameters
+    # Check if we need to calculate anyway
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     if groupby_columns is not None and len(list(groupby_columns)) == 0:
         raise ValueError("groupby_columns=[] is not supported. Use None.")
     if not input_path.exists():
@@ -1129,11 +1137,6 @@ def dissolve(
     if input_path == output_path:
         raise ValueError("output_path must not equal input_path")
 
-    # Check if we need to calculate anyway
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
-
-    # More complicated checks on input parameters
     if not isinstance(input_layer, LayerInfo):
         input_layer = gfo.get_layerinfo(input_path, input_layer)
 

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -1121,7 +1121,7 @@ def dissolve(
     operation_name = f"{operation_prefix}dissolve"
     logger = logging.getLogger(f"geofileops.{operation_name}")
 
-    # Check input parameters
+    # Basic checks on input parameters
     if groupby_columns is not None and len(list(groupby_columns)) == 0:
         raise ValueError("groupby_columns=[] is not supported. Use None.")
     if not input_path.exists():
@@ -1129,6 +1129,11 @@ def dissolve(
     if input_path == output_path:
         raise ValueError("output_path must not equal input_path")
 
+    # Check if we need to calculate anyway
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
+    # More complicated checks on input parameters
     if not isinstance(input_layer, LayerInfo):
         input_layer = gfo.get_layerinfo(input_path, input_layer)
 
@@ -1184,10 +1189,6 @@ def dissolve(
                 agg_column["column"] = _general_util.align_casing(
                     agg_column["column"], columns_available
                 )
-
-    # Now input parameters are checked, check if we need to calculate anyway
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
 
     # Check what we need to do in an error occurs
     on_data_error = ConfigOptions.on_data_error

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -87,7 +87,6 @@ def buffer(
         force_output_geometrytype = GeometryType.MULTIPOLYGON
 
     # Go!
-    # ---
     return _single_layer_vector_operation(
         input_path=input_path,
         output_path=output_path,
@@ -124,9 +123,6 @@ def convexhull(
     force: bool = False,
 ):
     # Init + prepare sql template for this operation
-    # ----------------------------------------------
-    if not isinstance(input_layer, LayerInfo):
-        input_layer = gfo.get_layerinfo(input_path, input_layer)
     sql_template = """
         SELECT ST_ConvexHull({geometrycolumn}) AS {geometrycolumn}
                 {columns_to_select_str}
@@ -135,9 +131,7 @@ def convexhull(
            {batch_filter}
     """
 
-    # Go!
-    # ---
-    # Output geometry type same as input geometry type
+    # TODO: output type is now always the same as input, but that's not correct.
     return _single_layer_vector_operation(
         input_path=input_path,
         output_path=output_path,
@@ -148,7 +142,7 @@ def convexhull(
         output_layer=output_layer,
         columns=columns,
         explodecollections=explodecollections,
-        force_output_geometrytype=input_layer.geometrytype,
+        force_output_geometrytype="KEEP_INPUT",
         gridsize=gridsize,
         keep_empty_geoms=keep_empty_geoms,
         where_post=where_post,
@@ -204,9 +198,6 @@ def delete_duplicate_geometries(
     """
 
     # Go!
-    if not isinstance(input_layer, LayerInfo):
-        input_layer = gfo.get_layerinfo(input_path, input_layer)
-
     return _single_layer_vector_operation(
         input_path=input_path,
         output_path=output_path,
@@ -217,7 +208,7 @@ def delete_duplicate_geometries(
         output_layer=output_layer,
         columns=columns,
         explodecollections=explodecollections,
-        force_output_geometrytype=input_layer.geometrytype,
+        force_output_geometrytype="KEEP_INPUT",
         gridsize=0.0,
         keep_empty_geoms=keep_empty_geoms,
         where_post=where_post,
@@ -317,11 +308,7 @@ def makevalid(
     batchsize: int = -1,
     force: bool = False,
 ):
-    # If output file already exists, either clean up or return...
-    operation_name = "makevalid"
-    logger = logging.getLogger(f"geofileops.{operation_name}")
-    if not force and output_path.exists():
-        logger.info(f"Stop, output already exists {output_path}")
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
         return
 
     # Determine output_geometrytype + make it multitype if it wasn't specified.
@@ -377,7 +364,7 @@ def makevalid(
         output_path=output_path,
         sql_template=sql_template,
         geom_selected=True,
-        operation_name=operation_name,
+        operation_name="makevalid",
         input_layer=input_layer,
         output_layer=output_layer,
         columns=columns,
@@ -410,10 +397,10 @@ def select(
     force: bool = False,
     operation_prefix: str = "",
 ):
-    # Check if output already exists here, to avoid to much logging to be written
-    logger = logging.getLogger(f"geofileops.{operation_prefix}select")
     if _io_util.output_exists(path=output_path, remove_if_exists=force):
         return
+
+    logger = logging.getLogger(f"geofileops.{operation_prefix}select")
     logger.debug(f"  -> select to execute:\n{sql_stmt}")
 
     # If no output geometrytype is specified, use the geometrytype of the input layer
@@ -479,10 +466,6 @@ def simplify(
             {{batch_filter}}
     """
 
-    # Output geometry type same as input geometry type
-    if not isinstance(input_layer, LayerInfo):
-        input_layer = gfo.get_layerinfo(input_path, input_layer)
-
     return _single_layer_vector_operation(
         input_path=input_path,
         output_path=output_path,
@@ -493,7 +476,7 @@ def simplify(
         output_layer=output_layer,
         columns=columns,
         explodecollections=explodecollections,
-        force_output_geometrytype=input_layer.geometrytype,
+        force_output_geometrytype="KEEP_INPUT",
         gridsize=gridsize,
         keep_empty_geoms=keep_empty_geoms,
         where_post=where_post,
@@ -514,7 +497,7 @@ def _single_layer_vector_operation(
     output_layer: str | None,
     columns: list[str] | None,
     explodecollections: bool,
-    force_output_geometrytype: GeometryType | None,
+    force_output_geometrytype: GeometryType | str | None,
     gridsize: float,
     keep_empty_geoms: bool,
     where_post: str | None,
@@ -556,6 +539,10 @@ def _single_layer_vector_operation(
     start_time = datetime.now()
     logger = logging.getLogger(f"geofileops.{operation_name}")
 
+    # If output file already exists, either clean up or return...
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     # Check/clean input parameters...
     if not input_path.exists():
         raise FileNotFoundError(f"{operation_name}: input_path not found: {input_path}")
@@ -573,9 +560,11 @@ def _single_layer_vector_operation(
     if output_layer is None:
         output_layer = gfo.get_default_layer(output_path)
 
-    # If output file already exists, either clean up or return...
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
+    if isinstance(force_output_geometrytype, str):
+        if force_output_geometrytype == "KEEP_INPUT":
+            force_output_geometrytype = input_layer.geometrytype
+        else:
+            raise ValueError(f"unsupported {force_output_geometrytype=}")
 
     # Determine if fid can be preserved
     preserve_fid = False
@@ -909,7 +898,9 @@ def clip(
     input_columns_prefix: str = "",
     output_with_spatial_index: bool | None = None,
 ):
-    # Init
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     # In the query, important to only extract the geometry types that are expected
     if not isinstance(input_layer, LayerInfo):
         input_layer = gfo.get_layerinfo(input_path, input_layer)
@@ -1050,6 +1041,9 @@ def difference(  # noqa: D417
     operation_name = f"{operation_prefix}difference"
     logger = logging.getLogger(f"geofileops.{operation_name}")
 
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     input1_layer, input2_layer, output_layer = _validate_params(
         input1_path=input1_path,
         input2_path=input2_path,
@@ -1059,8 +1053,6 @@ def difference(  # noqa: D417
         output_layer=output_layer,
         operation_name=operation_name,
     )
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
 
     # Determine output_geometrytype
     primitivetypeid = input1_layer.geometrytype.to_primitivetype.value
@@ -1449,12 +1441,9 @@ def export_by_location(
 
     operation_name = "export_by_location"
     logger = logging.getLogger(f"geofileops.{operation_name}")
-    if output_path.exists():
-        if not force:
-            logger.info(f"Stop, output already exists {output_path}")
-            return
-        else:
-            gfo.remove(output_path)
+
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
 
     start_time = datetime.now()
 
@@ -1588,10 +1577,6 @@ def export_by_location(
             WHERE sub_area.{area_inters_column_name} >= {min_area_intersect}
         """
 
-    if not isinstance(input_layer, LayerInfo):
-        input_layer = gfo.get_layerinfo(input_path, input_layer)
-
-    # Go!
     _two_layer_vector_operation(
         input1_path=input_path,
         input2_path=input_to_compare_with_path,
@@ -1606,7 +1591,7 @@ def export_by_location(
         input2_columns_prefix="",
         output_layer=output_layer,
         explodecollections=False,
-        force_output_geometrytype=input_layer.geometrytype,
+        force_output_geometrytype="KEEP_INPUT",
         gridsize=gridsize,
         where_post=where_post,
         nb_parallel=nb_parallel,
@@ -1659,10 +1644,6 @@ def export_by_distance(
                             layer2.{{input2_geometrycolumn}}) <= {max_distance})
     """
 
-    if not isinstance(input1_layer, LayerInfo):
-        input1_layer = gfo.get_layerinfo(input_to_select_from_path, input1_layer)
-
-    # Go!
     return _two_layer_vector_operation(
         input1_path=input_to_select_from_path,
         input2_path=input_to_compare_with_path,
@@ -1677,7 +1658,7 @@ def export_by_distance(
         input2_columns_prefix="",
         output_layer=output_layer,
         explodecollections=False,
-        force_output_geometrytype=input1_layer.geometrytype,
+        force_output_geometrytype="KEEP_INPUT",
         gridsize=gridsize,
         where_post=where_post,
         nb_parallel=nb_parallel,
@@ -1740,6 +1721,9 @@ def intersection(  # noqa: D417
     operation_name = f"{operation_prefix}intersection"
     logger = logging.getLogger(f"geofileops.{operation_name}")
 
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     input1_layer, input2_layer, output_layer = _validate_params(
         input1_path=input1_path,
         input2_path=input2_path,
@@ -1749,8 +1733,6 @@ def intersection(  # noqa: D417
         output_layer=output_layer,
         operation_name=operation_name,
     )
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
 
     # In the query, important to only extract the geometry types that are expected
     primitivetype_to_extract = PrimitiveType(
@@ -2091,10 +2073,6 @@ def join_by_location(
                    SELECT l1_fid FROM layer1_relations_filtered)
         """
 
-    if not isinstance(input1_layer, LayerInfo):
-        input1_layer = gfo.get_layerinfo(input1_path, input1_layer)
-
-    # Go!
     return _two_layer_vector_operation(
         input1_path=input1_path,
         input2_path=input2_path,
@@ -2109,7 +2087,7 @@ def join_by_location(
         input2_columns_prefix=input2_columns_prefix,
         output_layer=output_layer,
         explodecollections=explodecollections,
-        force_output_geometrytype=input1_layer.geometrytype,
+        force_output_geometrytype="KEEP_INPUT",
         gridsize=gridsize,
         where_post=where_post,
         nb_parallel=nb_parallel,
@@ -2378,10 +2356,9 @@ def join_nearest(
     # Init some things...
     # Because there is preprocessing done in this function, check output path
     # here already
-    logger = logging.getLogger("geofileops.join_nearest")
-    if output_path.exists() and force is False:
-        logger.info(f"Stop, output already exists {output_path}")
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
         return
+
     if input1_layer is None:
         input1_layer = gfo.get_only_layer(input1_path)
     if input2_layer is None:
@@ -2470,9 +2447,6 @@ def join_nearest(
                {{batch_filter}}
         """
 
-    input1_layer_info = gfo.get_layerinfo(input1_path, input1_layer)
-
-    # Go!
     return _two_layer_vector_operation(
         input1_path=input1_tmp_path,
         input2_path=input2_tmp_path,
@@ -2486,7 +2460,7 @@ def join_nearest(
         input2_columns=input2_columns,
         input2_columns_prefix=input2_columns_prefix,
         output_layer=output_layer,
-        force_output_geometrytype=input1_layer_info.geometrytype,
+        force_output_geometrytype="KEEP_INPUT",
         explodecollections=explodecollections,
         gridsize=0.0,
         where_post=None,
@@ -2575,6 +2549,9 @@ def identity(
 
     logger = logging.getLogger("geofileops.identity")
 
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     input1_layer, input2_layer, output_layer = _validate_params(
         input1_path=input1_path,
         input2_path=input2_path,
@@ -2584,8 +2561,6 @@ def identity(
         output_layer=output_layer,
         operation_name="identity",
     )
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
 
     tempdir = _io_util.create_tempdir("geofileops/identity")
     try:
@@ -2740,6 +2715,9 @@ def symmetric_difference(
         f"input2: {input2_path}, output: {output_path}"
     )
 
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     input1_layer, input2_layer, output_layer = _validate_params(
         input1_path=input1_path,
         input2_path=input2_path,
@@ -2749,8 +2727,6 @@ def symmetric_difference(
         output_layer=output_layer,
         operation_name="symmetric_difference",
     )
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
 
     tempdir = _io_util.create_tempdir("geofileops/symmdiff")
     try:
@@ -2911,6 +2887,9 @@ def union(
     operation_name = "union"
     logger = logging.getLogger(f"geofileops.{operation_name}")
 
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     input1_layer, input2_layer, output_layer = _validate_params(
         input1_path=input1_path,
         input2_path=input2_path,
@@ -2920,8 +2899,6 @@ def union(
         output_layer=output_layer,
         operation_name=operation_name,
     )
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
 
     start_time = datetime.now()
     tempdir = _io_util.create_tempdir("geofileops/union")
@@ -3090,7 +3067,7 @@ def _two_layer_vector_operation(
     input2_columns_prefix: str,
     output_layer: str | None,
     explodecollections: bool,
-    force_output_geometrytype: GeometryType | None,
+    force_output_geometrytype: GeometryType | str | None,
     gridsize: float,
     where_post: str | None,
     nb_parallel: int,
@@ -3127,7 +3104,8 @@ def _two_layer_vector_operation(
         output_layer (str): [description]. Defaults to None.
         explodecollections (bool, optional): Explode collecions in output.
             Defaults to False.
-        force_output_geometrytype (GeometryType, optional): Defaults to None.
+        force_output_geometrytype (GeometryType or str, optional): Defaults to None.
+            If "KEEP_INPUT", the geometry type of the input1_layer is used.
         gridsize (float, optional): the size of the grid the coordinates of the ouput
             will be rounded to. Eg. 0.001 to keep 3 decimals. Value 0.0 doesn't change
             the precision. Defaults to 0.0.
@@ -3163,6 +3141,9 @@ def _two_layer_vector_operation(
     # Init
     logger = logging.getLogger(f"geofileops.{operation_name}")
 
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     # Validate the input and output layer parameter
     input1_layer, input2_layer, output_layer = _validate_params(
         input1_path=input1_path,
@@ -3178,9 +3159,11 @@ def _two_layer_vector_operation(
             f"{operation_name}: if use_ogr True, input1_path should equal input2_path!"
         )
 
-    # Only check this after _validate_params to avoid files getting accidentely removed.
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
+    if isinstance(force_output_geometrytype, str):
+        if force_output_geometrytype == "KEEP_INPUT":
+            force_output_geometrytype = input1_layer.geometrytype
+        else:
+            raise ValueError(f"unsupported {force_output_geometrytype=}")
 
     # For columns params, if a string is passed, convert to list
     if isinstance(input1_columns, str):
@@ -4126,6 +4109,9 @@ def dissolve_singlethread(
     force: bool = False,
 ):
     """Remark: this is not a parallelized version!!!"""
+    if _io_util.output_exists(path=output_path, remove_if_exists=force):
+        return
+
     # Init
     logger = logging.getLogger("geofileops.dissolve")
     start_time = datetime.now()
@@ -4254,10 +4240,6 @@ def dissolve_singlethread(
                     f", {aggregation_str}({distinct_str}{column_str}{extra_param_str}) "
                     f'AS "{agg_column["as"]}"'
                 )
-
-    # Check output path
-    if _io_util.output_exists(path=output_path, remove_if_exists=force):
-        return
 
     # Now prepare the sql statement
     # Remark: calculating the area in the enclosing selects halves the processing time

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -544,10 +544,10 @@ def _single_layer_vector_operation(
         return
 
     # Check/clean input parameters...
-    if not input_path.exists():
-        raise FileNotFoundError(f"{operation_name}: input_path not found: {input_path}")
     if input_path == output_path:
         raise ValueError(f"{operation_name}: output_path must not equal input_path")
+    if not input_path.exists():
+        raise FileNotFoundError(f"{operation_name}: input_path not found: {input_path}")
     if where_post is not None and where_post == "":
         where_post = None
     if isinstance(columns, str):
@@ -3627,6 +3627,10 @@ def _validate_params(
         a tuple with the layers:
         input1_layer (LayerInfo), input2_layer (LayerInfo), output_layer (str)
     """
+    if output_path in (input1_path, input2_path):
+        raise ValueError(
+            f"{operation_name}: output_path must not equal one of input paths"
+        )
     if not input1_path.exists():
         raise FileNotFoundError(
             f"{operation_name}: input1_path not found: {input1_path}"
@@ -3634,10 +3638,6 @@ def _validate_params(
     if not input2_path.exists():
         raise FileNotFoundError(
             f"{operation_name}: input2_path not found: {input2_path}"
-        )
-    if output_path in (input1_path, input2_path):
-        raise ValueError(
-            f"{operation_name}: output_path must not equal one of input paths"
         )
 
     # Get layer info
@@ -4117,10 +4117,10 @@ def dissolve_singlethread(
     start_time = datetime.now()
 
     # Check input params
-    if not input_path.exists():
-        raise FileNotFoundError(f"input_path not found: {input_path}")
     if input_path == output_path:
         raise ValueError("output_path must not equal input_path")
+    if not input_path.exists():
+        raise FileNotFoundError(f"input_path not found: {input_path}")
     if where_post is not None and where_post == "":
         where_post = None
 

--- a/tests/single_layer_operations/test_geofileops_singlelayer.py
+++ b/tests/single_layer_operations/test_geofileops_singlelayer.py
@@ -377,8 +377,8 @@ def test_buffer_force(tmp_path, geoops_module):
         (
             "buffer: output_path must not equal input_path",
             ValueError,
-            test_helper.get_testfile("polygon-parcel"),
-            test_helper.get_testfile("polygon-parcel"),
+            "not_existing_path.gpkg",
+            "not_existing_path.gpkg",
         ),
         (
             "buffer: input_path not found:",

--- a/tests/single_layer_operations/test_geoops_dissolve.py
+++ b/tests/single_layer_operations/test_geoops_dissolve.py
@@ -496,8 +496,8 @@ def test_dissolve_emptyfile(tmp_path, testfile, suffix, explodecollections):
             "output_path must not equal input_path",
             ValueError,
             {
-                "input_path": test_helper.get_testfile("polygon-parcel"),
-                "output_path": test_helper.get_testfile("polygon-parcel"),
+                "input_path": Path("nonexisting.abc"),
+                "output_path": Path("nonexisting.abc"),
             },
         ),
         (

--- a/tests/two_layer_operations/test_geofileops_twolayers.py
+++ b/tests/two_layer_operations/test_geofileops_twolayers.py
@@ -736,16 +736,16 @@ def test_intersection_input_no_index(tmp_path):
         (
             "intersection: output_path must not equal one of input paths",
             ValueError,
-            test_helper.get_testfile("polygon-parcel"),
+            "not_existing_path",
             test_helper.get_testfile("polygon-zone"),
-            test_helper.get_testfile("polygon-parcel"),
+            Path("not_existing_path"),
         ),
         (
             "intersection: output_path must not equal one of input paths",
             ValueError,
             test_helper.get_testfile("polygon-parcel"),
-            test_helper.get_testfile("polygon-zone"),
-            test_helper.get_testfile("polygon-zone"),
+            Path("not_existing_path"),
+            Path("not_existing_path"),
         ),
         (
             "intersection: input1_path not found",
@@ -1571,16 +1571,16 @@ def test_select_two_layers_input_without_geom(tmp_path, suffix, input_nogeom):
         (
             "select_two_layers: output_path must not equal one of input paths",
             ValueError,
-            test_helper.get_testfile("polygon-parcel"),
+            Path("non_existing_input.gpkg"),
             test_helper.get_testfile("polygon-zone"),
-            test_helper.get_testfile("polygon-parcel"),
+            Path("non_existing_input.gpkg"),
         ),
         (
             "select_two_layers: output_path must not equal one of input paths",
             ValueError,
             test_helper.get_testfile("polygon-parcel"),
-            test_helper.get_testfile("polygon-zone"),
-            test_helper.get_testfile("polygon-zone"),
+            Path("non_existing_input.gpkg"),
+            Path("non_existing_input.gpkg"),
         ),
         (
             "select_two_layers: input1_path not found: not_existing_path",


### PR DESCRIPTION
The idea is that if the output file exists already and `force=False`, that no processing is done and hence dealing with that is fast.

However, if the input geopackages don't have a filled out gpkg_ogr_contents.featurecount table/column, in many cases this seems to take quite some time anyway.

This PR moves the output_exists check forward on many places to speed this up. Disadvantage is that most input parameter checks are now afterwards...

reference #695