### PR TITLE
BUG: fix copy_file for some special vsi cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   versions + small refactor (#693)
 - Improve performance of two-layer operations using `nb_parallel=1` (#692)
 
+### Bugs fixed
+
+- Fix `copy_file` for some special vsi cases (#703)
+
 ## 0.10.1 (2025-05-16)
 
 ### Deprecations and compatibility notes

--- a/geofileops/util/_geofileinfo.py
+++ b/geofileops/util/_geofileinfo.py
@@ -166,7 +166,7 @@ class GeofileInfo:
         driver (str): the relevant gdal driver for the file.
     """
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Union[str, "os.PathLike[Any]"]):
         """Constructor of Layerinfo.
 
         Args:
@@ -262,7 +262,7 @@ def get_driver(path: Union[str, "os.PathLike[Any]"]) -> str:
                 f"Path: {input_path}"
             )
 
-    # If the file exists, determine the driver based on the file.
+    # Try to determine the driver by opening the file.
     try:
         datasource = gdal.OpenEx(
             str(path), nOpenFlags=gdal.OF_VECTOR | gdal.OF_READONLY | gdal.OF_SHARED
@@ -270,9 +270,20 @@ def get_driver(path: Union[str, "os.PathLike[Any]"]) -> str:
         driver = datasource.GetDriver()
         drivername = driver.ShortName
     except Exception as ex:
-        try:
-            drivername = get_driver_for_path(path)
-        except Exception:
+        ex_str = str(ex).lower()
+        if (
+            "no such file or directory" in ex_str
+            or "not recognized as being in a supported file format" in ex_str
+        ):
+            # If the file does not exist or if, for some cases like a csv file,
+            # it is e.g. an empty file that was not recognized yet, try to get the
+            # driver based on only the path.
+            try:
+                drivername = get_driver_for_path(path)
+            except Exception:
+                ex.args = (f"get_driver error for {path}: {ex}",)
+                raise
+        else:
             ex.args = (f"get_driver error for {path}: {ex}",)
             raise
     finally:
@@ -293,4 +304,4 @@ def get_geofileinfo(path: Union[str, "os.PathLike[Any]"]) -> GeofileInfo:
     Returns:
         GeofileInfo: _description_
     """
-    return GeofileInfo(path=Path(path))
+    return GeofileInfo(path=path)

--- a/geofileops/util/_geofileinfo.py
+++ b/geofileops/util/_geofileinfo.py
@@ -274,6 +274,7 @@ def get_driver(path: Union[str, "os.PathLike[Any]"]) -> str:
         if (
             "no such file or directory" in ex_str
             or "not recognized as being in a supported file format" in ex_str
+            or "not recognized as a supported file format" in ex_str
         ):
             # If the file does not exist or if, for some cases like a csv file,
             # it is e.g. an empty file that was not recognized yet, try to get the

--- a/tests/general_file_layer_operations/test_geofile.py
+++ b/tests/general_file_layer_operations/test_geofile.py
@@ -828,9 +828,17 @@ def test_copy_layer_to_gpkg_zip(tmp_path):
     assert_geodataframe_equal(src_gdf, dst_gdf)
 
 
-def test_copy_layer_vsi(tmp_path):
+@pytest.mark.parametrize(
+    "src",
+    [
+        f"/vsizip//vsicurl/{test_helper.data_url}/poly_shp.zip",
+        f"/vsizip//vsicurl/{test_helper.data_url}/poly_shp.zip/poly.shp",
+        f"/vsizip/{test_helper.data_dir.as_posix()}/poly_shp.zip",
+        f"/vsizip/{test_helper.data_dir.as_posix()}/poly_shp.zip/poly.shp",
+    ],
+)
+def test_copy_layer_vsi(tmp_path, src):
     # Prepare test data
-    src = f"/vsizip//vsicurl/{test_helper.data_url}/poly_shp.zip/poly.shp"
     dst = tmp_path / "output.gpkg"
 
     # copy_layer with vsi

--- a/tests/util/test_geofileinfo.py
+++ b/tests/util/test_geofileinfo.py
@@ -89,35 +89,37 @@ def test_get_driver_unsupported_suffix_driverprefix(tmp_path):
     assert gfo.get_driver(f"CSV:{unsupported_path}") == "CSV"
 
 
-def test_get_geofileinfo():
-    # Test ESRIShapefile geofiletype
-    # Test getting a geofiletype for a suffix
-    info = _geofileinfo.get_geofileinfo(".shp")
+@pytest.mark.parametrize(
+    "suffix, exp_driver, exp_is_fid_zerobased, exp_is_singlelayer, "
+    "exp_is_spatialite_based",
+    [
+        (".shp", "ESRI Shapefile", True, True, False),
+        (".gpkg", "GPKG", False, False, True),
+        (".gpKG", "GPKG", False, False, True),
+        (".sqlite", "SQLite", False, False, True),
+        (".csv", "CSV", False, True, False),
+    ],
+)
+def test_get_geofileinfo_for_suffix(
+    suffix,
+    exp_driver,
+    exp_is_fid_zerobased,
+    exp_is_singlelayer,
+    exp_is_spatialite_based,
+):
+    """Test getting a geofiletype for some common suffixes."""
+    info = _geofileinfo.get_geofileinfo(suffix)
+    assert info.driver == exp_driver
+    assert info.is_fid_zerobased == exp_is_fid_zerobased
+    assert info.is_singlelayer == exp_is_singlelayer
+    assert info.is_spatialite_based == exp_is_spatialite_based
+
+
+def test_get_geofileinfo_for_vsi():
+    """Test getting a geofiletype for a VSI path."""
+    vsi_path = f"/vsizip/vsicurl/{test_helper.data_url}/poly_shp.zip"
+    info = _geofileinfo.get_geofileinfo(vsi_path)
     assert info.driver == "ESRI Shapefile"
-    assert info.is_fid_zerobased
-    assert info.is_singlelayer
-    assert not info.is_spatialite_based
-
-    # GPKG geofiletype
-    # Test getting a geofiletype for a suffix
-    info = _geofileinfo.get_geofileinfo(".gpKG")
-    assert info.driver == "GPKG"
-    assert not info.is_fid_zerobased
-    assert not info.is_singlelayer
-    assert info.is_spatialite_based
-
-    # SQLite geofiletype
-    # Test getting a geofiletype for a suffix
-    info = _geofileinfo.get_geofileinfo(".sqlite")
-    assert info.driver == "SQLite"
-    assert not info.is_fid_zerobased
-    assert not info.is_singlelayer
-    assert info.is_spatialite_based
-
-    # CSV geofiletype
-    # Test getting a geofiletype for a suffix
-    info = _geofileinfo.get_geofileinfo(".csv")
-    assert info.driver == "CSV"
-    assert not info.is_fid_zerobased
-    assert info.is_singlelayer
-    assert not info.is_spatialite_based
+    assert info.is_fid_zerobased is True
+    assert info.is_singlelayer is True
+    assert info.is_spatialite_based is False


### PR DESCRIPTION
E.g. when using a .zip file as source file with /vsizip/, `copy_file` gives an error while this should work.

Also improves error messages in some cases.