### PR TITLE
ENH: add checks on invalid values in `ConfigOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Improve performance of two-layer operations using `nb_parallel=1` (#692)
 - Support to specify the directory used by geofileops to put temporary files via an
   environment variable (GFO_TMPDIR) (#707)
+- Add checks on invalid values in `ConfigOptions` (#711)
 
 ### Bugs fixed
 

--- a/geofileops/helpers/_configoptions_helper.py
+++ b/geofileops/helpers/_configoptions_helper.py
@@ -35,8 +35,8 @@ class ConfigOptions:
         supported_values = ["raise", "warn"]
         if value_cleaned not in supported_values:
             raise ValueError(
-                f"invalid value for configoption <GFO_ON_DATA_ERROR>: {value}, should "
-                f"be one of {supported_values}"
+                f"invalid value for configoption <GFO_ON_DATA_ERROR>: '{value}', "
+                f"should be one of {supported_values}"
             )
 
         return value_cleaned
@@ -44,7 +44,15 @@ class ConfigOptions:
     @classproperty
     def io_engine(cls):
         """The IO engine to use."""
-        return os.environ.get("GFO_IO_ENGINE", default="pyogrio").strip().lower()
+        io_engine = os.environ.get("GFO_IO_ENGINE", default="pyogrio").strip().lower()
+        supported_values = ["pyogrio", "fiona"]
+        if io_engine not in supported_values:
+            raise ValueError(
+                f"invalid value for configoption <GFO_IO_ENGINE>: '{io_engine}', "
+                f"should be one of {supported_values}"
+            )
+
+        return io_engine
 
     @classproperty
     def remove_temp_files(cls) -> bool:
@@ -67,7 +75,15 @@ class ConfigOptions:
         Returns:
             str: the type of workers to use. Defaults to "auto".
         """
-        return os.environ.get("GFO_WORKER_TYPE", default="auto").strip().lower()
+        worker_type = os.environ.get("GFO_WORKER_TYPE", default="auto").strip().lower()
+        supported_values = ["thread", "process", "auto"]
+        if worker_type not in supported_values:
+            raise ValueError(
+                f"invalid value for configoption <GFO_WORKER_TYPE>: '{worker_type}', "
+                f"should be one of {supported_values}"
+            )
+
+        return worker_type
 
 
 def get_bool(key: str, default: bool) -> bool:

--- a/tests/helpers/test_configoptions_helper.py
+++ b/tests/helpers/test_configoptions_helper.py
@@ -49,19 +49,71 @@ def test_get_bool_invalidvalue():
 
 
 @pytest.mark.parametrize(
-    "value, expected",
-    [("TRUE", True), ("FALSE", False), (None, True)],
+    "key, value, expected",
+    [
+        ("GFO_IO_ENGINE", "PYOgrio", "pyogrio"),
+        ("GFO_IO_ENGINE", "FIOna", "fiona"),
+        ("GFO_IO_ENGINE", None, "pyogrio"),
+        ("GFO_ON_DATA_ERROR", "RAIse", "raise"),
+        ("GFO_ON_DATA_ERROR", "WARn", "warn"),
+        ("GFO_ON_DATA_ERROR", None, "raise"),
+        ("GFO_REMOVE_TEMP_FILES", "TRUe", True),
+        ("GFO_REMOVE_TEMP_FILES", "FALse", False),
+        ("GFO_REMOVE_TEMP_FILES", None, True),
+        ("GFO_WORKER_TYPE", "THRead", "thread"),
+        ("GFO_WORKER_TYPE", "PROcess", "process"),
+        ("GFO_WORKER_TYPE", "AUTo", "auto"),
+        ("GFO_WORKER_TYPE", None, "auto"),
+    ],
 )
-def test_remove_temp_files(value, expected):
-    test_key = "GFO_REMOVE_TEMP_FILES"
-    if value is None:
-        if test_key in os.environ:
-            del os.environ[test_key]
-    else:
-        os.environ[test_key] = value
+def test_configoptions(key, value, expected):
+    """Test all ConfigOptions class properties."""
+    with gfo.TempEnv({key: value}):
+        if key == "GFO_IO_ENGINE":
+            result = ConfigOptions.io_engine
+        elif key == "GFO_ON_DATA_ERROR":
+            result = ConfigOptions.on_data_error
+        elif key == "GFO_REMOVE_TEMP_FILES":
+            result = ConfigOptions.remove_temp_files
+        elif key == "GFO_WORKER_TYPE":
+            result = ConfigOptions.worker_type
+        else:
+            raise ValueError(f"Unexpected key: {key}")
 
-    result = ConfigOptions.remove_temp_files
-    if test_key in os.environ:
-        del os.environ[test_key]
+    assert result == expected
 
-    assert result is expected
+
+@pytest.mark.parametrize(
+    "key, invalid_value, expected_error",
+    [
+        ("GFO_IO_ENGINE", "invalid", "invalid value for configoption <GFO_IO_ENGINE>"),
+        (
+            "GFO_ON_DATA_ERROR",
+            "invalid",
+            "invalid value for configoption <GFO_ON_DATA_ERROR>",
+        ),
+        (
+            "GFO_REMOVE_TEMP_FILES",
+            "invalid",
+            "invalid value for bool configoption <GFO_REMOVE_TEMP_FILES>",
+        ),
+        (
+            "GFO_WORKER_TYPE",
+            "invalid",
+            "invalid value for configoption <GFO_WORKER_TYPE>",
+        ),
+    ],
+)
+def test_configoptions_invalid(key, invalid_value, expected_error):
+    with gfo.TempEnv({key: invalid_value}):
+        with pytest.raises(ValueError, match=expected_error):
+            if key == "GFO_IO_ENGINE":
+                _ = ConfigOptions.io_engine
+            elif key == "GFO_ON_DATA_ERROR":
+                _ = ConfigOptions.on_data_error
+            elif key == "GFO_REMOVE_TEMP_FILES":
+                _ = ConfigOptions.remove_temp_files
+            elif key == "GFO_WORKER_TYPE":
+                _ = ConfigOptions.worker_type
+            else:
+                raise ValueError(f"Unexpected key: {key}")


### PR DESCRIPTION
For some config options invalid values were just ignored... Now, a ValueError will be raised.