### PR TITLE
[backport] BUG: disable arrow in gdal.VectorTranslate to avoid random crashes (#714)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.10.2 (2025-08-20)
+
+### Bugs fixed
+
+- Disable arrow in `gdal.VectorTranslate` to avoid random crashes (#714)
+
 ## 0.10.1 (2025-05-16)
 
 ### Deprecations and compatibility notes

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -13,7 +13,7 @@ from osgeo import gdal, ogr
 from pygeoops import GeometryType
 
 import geofileops as gfo
-from geofileops import _compat, fileops
+from geofileops import fileops
 from geofileops.util import _geopath_util
 from geofileops.util._general_util import MissingRuntimeDependencyError
 

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -497,8 +497,11 @@ def vector_translate(
     input_has_geometry_attribute = False
     try:
         # Till gdal 3.10 datetime columns can be interpreted wrongly with arrow.
-        if _compat.GDAL_ST_311 and "OGR2OGR_USE_ARROW_API" not in config_options:
-            config_options["OGR2OGR_USE_ARROW_API"] = False
+        # Additionally, enabling arrow seems to lead to (rare) random crashes, so
+        # for now, disable it by default.
+        use_arrow_key = "OGR2OGR_USE_ARROW_API"
+        if use_arrow_key not in config_options and use_arrow_key not in os.environ:
+            config_options[use_arrow_key] = False
 
         # Go!
         with set_config_options(config_options):


### PR DESCRIPTION
When running large analysis, recently (rare) random crashes started occuring, without any error reporting at all.

It looks like it is linked with arrow being used in `gdal.VectorTranslate`. Arrow was already disabled for GDAL < 3.11, this PR disables it for all GDAL versions (till this is cleared out) by setting GDAL configuration option `OGR2OGR_USE_ARROW_API=NO`.