### PR TITLE
PERF: improve performance of gpkg to gpkg appends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Improvements
 
+- Improve performance of most operations by using a direct gpkg to gpkg append via
+  sqlite where possible (#728)
 - Ensure that the featurecount is properly cached in GPKG files, also for older GDAL
   versions + small refactor (#693)
 - Improve performance of two-layer operations using `nb_parallel=1` (#692)

--- a/benchmark/benchmark_geofileops.py
+++ b/benchmark/benchmark_geofileops.py
@@ -11,11 +11,12 @@ def main():
         # "join_by_location_intersects",
         # "clip",
         # "intersection",
-        "intersection_complexpoly_agri",
+        # "intersection_complexpoly_agri",
         # "intersection_complexpoly_complexpoly",
         # "intersection_gridsize",
         # "symmetric_difference_complexpolys_agri",
         # "union",
+        "buffer_spatialite",
     ]
     # Run all bechmark functions
     # functions_to_run = None

--- a/benchmark/benchmarks/benchmarks_geofileops.py
+++ b/benchmark/benchmarks/benchmarks_geofileops.py
@@ -161,7 +161,7 @@ def dissolve_groupby(tmp_dir: Path) -> RunResult:
     gfo.dissolve(
         input_path,
         output_path,
-        groupby_columns=["GEWASGROEP"],
+        groupby_columns=["LANDBSTR"],
         explodecollections=True,
         nb_parallel=nb_parallel,
         force=True,
@@ -171,7 +171,7 @@ def dissolve_groupby(tmp_dir: Path) -> RunResult:
         package_version=_get_version(),
         operation="dissolve_groupby",
         secs_taken=(datetime.now() - start_time).total_seconds(),
-        operation_descr=("dissolve on {input_descr}, groupby=[GEWASGROEP]"),
+        operation_descr=("dissolve on {input_descr}, groupby=[LANDBSTR]"),
         run_details={"nb_cpu": nb_parallel},
     )
 

--- a/geofileops/_compat.py
+++ b/geofileops/_compat.py
@@ -15,6 +15,7 @@ gdal.UseExceptions()
 # must be dropped for the version checks here.
 GDAL_BASE_VERSION = version.parse(gdal.__version__.split("-")[0]).base_version
 GDAL_GTE_38 = version.parse(GDAL_BASE_VERSION) >= version.parse("3.8")
+GDAL_GTE_39 = version.parse(GDAL_BASE_VERSION) >= version.parse("3.9")
 GDAL_GTE_3101 = version.parse(GDAL_BASE_VERSION) >= version.parse("3.10.1")
 GDAL_ST_311 = version.parse(GDAL_BASE_VERSION) < version.parse("3.11")
 

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -2746,7 +2746,7 @@ def copy_layer(
         # TODO: create gfo config option to disable?
         try:
             name = src_layername if src_layername is not None else get_only_layer(src)
-            preserve_fid_local = preserve_fid if preserve_fid is not None else True
+            preserve_fid_local = preserve_fid if preserve_fid is not None else False
             _sqlite_util.copy_table(
                 input_path=src,
                 output_path=dst,

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -2723,7 +2723,7 @@ def copy_layer(
     src_layername = src_layer.name if isinstance(src_layer, LayerInfo) else src_layer
 
     # If the source and destination files are GeoPackages, and it involves a simple data
-    # copy, it is faster to copy the data directly in sqlite instead of with GDAL.
+    # copy, it is faster to copy the data directly in sqlite instead of via GDAL.
     if (
         access_mode == "append"
         and Path(src).suffix.lower() == ".gpkg"
@@ -2739,6 +2739,7 @@ def copy_layer(
         and dst_crs is None
         and Path(src).exists()
         and Path(dst).exists()
+        and ConfigOptions.copy_layer_sqlite_direct
     ):
         # TODO: sql_stmt?, access_mode="create", create_spatial_index, dst_crs?
         # TODO: create gfo config option to disable?

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -2730,7 +2730,6 @@ def copy_layer(
         and Path(dst).suffix.lower() == ".gpkg"
         and not sql_stmt
         and (sql_dialect is None or sql_dialect == "SQLITE")
-        and not columns
         and not explodecollections
         and not reproject
         and force_output_geometrytype is None
@@ -2741,8 +2740,7 @@ def copy_layer(
         and Path(src).exists()
         and Path(dst).exists()
     ):
-        # TODO: columns, sql_stmt?, access_mode="create", create_spatial_index
-        #       dst_crs?
+        # TODO: sql_stmt?, access_mode="create", create_spatial_index, dst_crs?
         # TODO: create gfo config option to disable?
         try:
             name = src_layername if src_layername is not None else get_only_layer(src)
@@ -2752,6 +2750,7 @@ def copy_layer(
                 output_path=dst,
                 input_table=name,
                 output_table=dst_layer,
+                columns=columns,
                 where=where,
                 preserve_fid=preserve_fid_local,
             )

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -2758,7 +2758,7 @@ def copy_layer(
             return
 
         except Exception as ex:
-            logger.debug(
+            logger.info(
                 f"Failed to copy data directly in sqlite, retry with gdal: {ex}"
             )
 

--- a/geofileops/helpers/_configoptions_helper.py
+++ b/geofileops/helpers/_configoptions_helper.py
@@ -13,6 +13,31 @@ class ConfigOptions:
     """
 
     @classproperty
+    def copy_layer_sqlite_direct(cls) -> bool:
+        """Should copy_layer use sqlite directly when possible.
+
+        This is significantly faster than using GDAL for large datasets. At the moment
+        only used for .gpkg files.
+
+        Returns:
+            bool: True to use sqlite directly to copy layers. Defaults to True.
+        """
+        return get_bool("GFO_COPY_LAYER_SQLITE_DIRECT", default=True)
+
+    @classproperty
+    def io_engine(cls):
+        """The IO engine to use."""
+        io_engine = os.environ.get("GFO_IO_ENGINE", default="pyogrio").strip().lower()
+        supported_values = ["pyogrio", "fiona"]
+        if io_engine not in supported_values:
+            raise ValueError(
+                f"invalid value for configoption <GFO_IO_ENGINE>: '{io_engine}', "
+                f"should be one of {supported_values}"
+            )
+
+        return io_engine
+
+    @classproperty
     def on_data_error(cls) -> str:
         """The preferred action when a data error occurs.
 
@@ -40,19 +65,6 @@ class ConfigOptions:
             )
 
         return value_cleaned
-
-    @classproperty
-    def io_engine(cls):
-        """The IO engine to use."""
-        io_engine = os.environ.get("GFO_IO_ENGINE", default="pyogrio").strip().lower()
-        supported_values = ["pyogrio", "fiona"]
-        if io_engine not in supported_values:
-            raise ValueError(
-                f"invalid value for configoption <GFO_IO_ENGINE>: '{io_engine}', "
-                f"should be one of {supported_values}"
-            )
-
-        return io_engine
 
     @classproperty
     def remove_temp_files(cls) -> bool:

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -899,7 +899,6 @@ def _apply_geooperation_to_layer(
                                 dst_layer=output_layer,
                                 write_mode="append",
                                 explodecollections=explodecollections,
-                                # force_output_geometrytype=force_output_geometrytype,
                                 create_spatial_index=False,
                                 where=where_post,
                                 preserve_fid=preserve_fid,

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -883,10 +883,10 @@ def _apply_geooperation_to_layer(
                         # operations is (a lot) more limited than gdal-based, use the
                         # gdal version via _append_to_nolock.
                         if (
-                            nb_batches == 1
-                            and force_output_geometrytype is None
-                            and tmp_partial_output_path.suffix == tmp_output_path.suffix
+                            force_output_geometrytype is None
                             and where_post is None
+                            and tmp_partial_output_path.suffix == tmp_output_path.suffix
+                            and not tmp_output_path.exists()
                         ):
                             gfo.move(tmp_partial_output_path, tmp_output_path)
                         else:
@@ -1758,15 +1758,21 @@ def _dissolve_polygons_pass(
                         output_notonborder_tmp_partial_path.exists()
                         and output_notonborder_tmp_partial_path.stat().st_size > 0
                     ):
-                        fileops.copy_layer(
-                            src=output_notonborder_tmp_partial_path,
-                            dst=output_notonborder_path,
-                            src_layer=output_layer,
-                            dst_layer=output_layer,
-                            write_mode="append",
-                            create_spatial_index=False,
-                        )
-                        gfo.remove(output_notonborder_tmp_partial_path)
+                        if not output_notonborder_path.exists():
+                            fileops.move(
+                                src=output_notonborder_tmp_partial_path,
+                                dst=output_notonborder_path,
+                            )
+                        else:
+                            fileops.copy_layer(
+                                src=output_notonborder_tmp_partial_path,
+                                dst=output_notonborder_path,
+                                src_layer=output_layer,
+                                dst_layer=output_layer,
+                                write_mode="append",
+                                create_spatial_index=False,
+                            )
+                            gfo.remove(output_notonborder_tmp_partial_path)
 
                     # If calculate gave onborder results, append to output
                     output_onborder_tmp_partial_path = batches[batch_id][
@@ -1776,15 +1782,21 @@ def _dissolve_polygons_pass(
                         output_onborder_tmp_partial_path.exists()
                         and output_onborder_tmp_partial_path.stat().st_size > 0
                     ):
-                        fileops.copy_layer(
-                            src=output_onborder_tmp_partial_path,
-                            dst=output_onborder_path,
-                            src_layer=output_layer,
-                            dst_layer=output_layer,
-                            write_mode="append",
-                            create_spatial_index=False,
-                        )
-                        gfo.remove(output_onborder_tmp_partial_path)
+                        if not output_onborder_path.exists():
+                            fileops.move(
+                                src=output_onborder_tmp_partial_path,
+                                dst=output_onborder_path,
+                            )
+                        else:
+                            fileops.copy_layer(
+                                src=output_onborder_tmp_partial_path,
+                                dst=output_onborder_path,
+                                src_layer=output_layer,
+                                dst_layer=output_layer,
+                                write_mode="append",
+                                create_spatial_index=False,
+                            )
+                            gfo.remove(output_onborder_tmp_partial_path)
 
             except Exception as ex:
                 batch_id = future_to_batch_id[future]

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -880,13 +880,10 @@ def _apply_geooperation_to_layer(
                         tmp_partial_output_path.exists()
                         and tmp_partial_output_path.stat().st_size > 0
                     ):
-                        # Remark: because force_output_geometrytype for GeoDataFrame
-                        # operations is (a lot) more limited than gdal-based, use the
-                        # gdal version via copy_layer.
+                        # Remark: force_output_geometrytype and explodecollections have
+                        # already been applied in the calculation step.
                         if (
-                            not explodecollections
-                            and force_output_geometrytype is None
-                            and where_post is None
+                            where_post is None
                             and tmp_partial_output_path.suffix == tmp_output_path.suffix
                             and not tmp_output_path.exists()
                         ):
@@ -898,7 +895,6 @@ def _apply_geooperation_to_layer(
                                 src_layer=output_layer,
                                 dst_layer=output_layer,
                                 write_mode="append",
-                                explodecollections=explodecollections,
                                 create_spatial_index=False,
                                 where=where_post,
                                 preserve_fid=preserve_fid,

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -1410,6 +1410,7 @@ def dissolve(
                     output_tmp_path,
                     dst_layer=output_layer,
                     write_mode="append",
+                    preserve_fid=False,
                 )
 
             # If there is a result...
@@ -1772,6 +1773,7 @@ def _dissolve_polygons_pass(
                                 dst_layer=output_layer,
                                 write_mode="append",
                                 create_spatial_index=False,
+                                preserve_fid=False,
                             )
                             gfo.remove(output_notonborder_tmp_partial_path)
 

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -1799,6 +1799,7 @@ def _dissolve_polygons_pass(
                                 dst_layer=output_layer,
                                 write_mode="append",
                                 create_spatial_index=False,
+                                preserve_fid=False,
                             )
                             gfo.remove(output_onborder_tmp_partial_path)
 

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -881,9 +881,10 @@ def _apply_geooperation_to_layer(
                     ):
                         # Remark: because force_output_geometrytype for GeoDataFrame
                         # operations is (a lot) more limited than gdal-based, use the
-                        # gdal version via _append_to_nolock.
+                        # gdal version via copy_layer.
                         if (
-                            force_output_geometrytype is None
+                            not explodecollections
+                            and force_output_geometrytype is None
                             and where_post is None
                             and tmp_partial_output_path.suffix == tmp_output_path.suffix
                             and not tmp_output_path.exists()

--- a/geofileops/util/_geoops_gpd.py
+++ b/geofileops/util/_geoops_gpd.py
@@ -843,6 +843,7 @@ def _apply_geooperation_to_layer(
                     output_layer=output_layer,
                     where=batch_filter,
                     explodecollections=explodecollections,
+                    force_output_geometrytype=force_output_geometrytype,
                     gridsize=gridsize,
                     keep_empty_geoms=keep_empty_geoms,
                     preserve_fid=preserve_fid,
@@ -898,8 +899,8 @@ def _apply_geooperation_to_layer(
                                 dst_layer=output_layer,
                                 write_mode="append",
                                 explodecollections=explodecollections,
+                                # force_output_geometrytype=force_output_geometrytype,
                                 create_spatial_index=False,
-                                force_output_geometrytype=force_output_geometrytype,
                                 where=where_post,
                                 preserve_fid=preserve_fid,
                             )
@@ -947,6 +948,7 @@ def _apply_geooperation(
     columns: list[str] | None = None,
     where=None,
     explodecollections: bool = False,
+    force_output_geometrytype: GeometryType | str | None = None,
     gridsize: float = 0.0,
     keep_empty_geoms: bool = False,
     preserve_fid: bool = False,
@@ -1033,11 +1035,11 @@ def _apply_geooperation(
 
     # If the result is empty, and no output geometrytype specified, use input
     # geometrytype
-    force_output_geometrytype = None
-    if len(data_gdf) == 0:
-        force_output_geometrytype = input_layer.geometrytype
-        if not explodecollections:
-            force_output_geometrytype = force_output_geometrytype.to_multitype
+    if force_output_geometrytype is None and len(data_gdf) == 0:
+        if explodecollections:
+            force_output_geometrytype = input_layer.geometrytype.to_singletype
+        else:
+            force_output_geometrytype = input_layer.geometrytype.to_multitype
 
     # If the index is still unique, save it to fid column so to_file can save it
     if preserve_fid:

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -825,12 +825,13 @@ def _single_layer_vector_operation(
                             geometrycolumn=info.geometrycolumn
                         )
 
+                    # force_output_geometrytype has already been applied above, so need
+                    # to specify it here anymore.
                     fileops.copy_layer(
                         src=tmp_partial_output_path,
                         dst=tmp_output_path,
                         write_mode="append",
                         explodecollections=explodecollections,
-                        force_output_geometrytype=force_output_geometrytype,
                         where=where_post,
                         create_spatial_index=False,
                         preserve_fid=preserve_fid,

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -81,7 +81,7 @@ def buffer(
               {{batch_filter}}
     """
 
-    # Buffer operation always results in polygons...
+    # Buffer operation always results in 2D polygons...
     if explodecollections:
         force_output_geometrytype = GeometryType.POLYGON
     else:
@@ -832,7 +832,6 @@ def _single_layer_vector_operation(
                         dst=tmp_output_path,
                         write_mode="append",
                         explodecollections=explodecollections,
-                        force_output_geometrytype=force_output_geometrytype,
                         where=where_post,
                         create_spatial_index=False,
                         preserve_fid=preserve_fid,

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -832,6 +832,7 @@ def _single_layer_vector_operation(
                         dst=tmp_output_path,
                         write_mode="append",
                         explodecollections=explodecollections,
+                        force_output_geometrytype=force_output_geometrytype,
                         where=where_post,
                         create_spatial_index=False,
                         preserve_fid=preserve_fid,

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -3443,7 +3443,9 @@ def _two_layer_vector_operation(
         if output_geometrytype_calc is not None and "geom" in column_datatypes:
             column_datatypes["geom"] = output_geometrytype_calc.name
         output_geometrytype_append = (
-            force_output_geometrytype if explode_append else None
+            force_output_geometrytype
+            if explode_append or output_path.suffix == ".shp"
+            else None
         )
 
         worker_type = _general_helper.worker_type_to_use(input1_layer.featurecount)

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -3436,8 +3436,8 @@ def _two_layer_vector_operation(
         # be applied, it needs to be applied during calculation already.
         # Otherwise the where_post in the append of partial files later on
         # won't give correct results!
-        explode_calc = True if explodecollections and not where_post else False
-        explode_append = not explode_calc
+        explode_calc = True if explodecollections and where_post is not None else False
+        explode_append = True if explodecollections and not explode_calc else False
 
         # Apply the geometrytype already during calculation
         output_geometrytype_calc = force_output_geometrytype

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -824,6 +824,7 @@ def _single_layer_vector_operation(
                         where_post = where_post.format(
                             geometrycolumn=info.geometrycolumn
                         )
+                    
                     fileops.copy_layer(
                         src=tmp_partial_output_path,
                         dst=tmp_output_path,
@@ -834,6 +835,20 @@ def _single_layer_vector_operation(
                         create_spatial_index=False,
                         preserve_fid=preserve_fid,
                     )
+                    """
+                    if not tmp_output_path.exists():
+                        # If the output file does not exist yet, just move the
+                        # partial file to the output file.
+                        gfo.move(tmp_partial_output_path, tmp_output_path)
+                    else:
+                        _sqlite_util.append_table_to_table(
+                            input_path=tmp_partial_output_path,
+                            output_path=tmp_output_path,
+                            input_table=output_layer,
+                            output_table=output_layer,
+                            profile=_sqlite_util.SqliteProfile.DEFAULT,
+                        )
+                    """
                     gfo.remove(tmp_partial_output_path)
 
                 # Log the progress and prediction speed

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -825,13 +825,12 @@ def _single_layer_vector_operation(
                             geometrycolumn=info.geometrycolumn
                         )
 
-                    # force_output_geometrytype has already been applied above, so need
-                    # to specify it here anymore.
+                    # force_output_geometrytype and explodecollections have already been
+                    # applied during calculation, so need to apply it here anymore.
                     fileops.copy_layer(
                         src=tmp_partial_output_path,
                         dst=tmp_output_path,
                         write_mode="append",
-                        explodecollections=explodecollections,
                         where=where_post,
                         create_spatial_index=False,
                         preserve_fid=preserve_fid,

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -3440,16 +3440,11 @@ def _two_layer_vector_operation(
 
         # Apply the geometrytype already during calculation
         output_geometrytype_calc = force_output_geometrytype
-        if (
-            force_output_geometrytype is not None
-            and explodecollections
-            and not explode_calc
-        ):
-            # convert geometrytype to multitype to avoid ogr warnings
-            output_geometrytype_calc = force_output_geometrytype.to_multitype  # type: ignore[union-attr]
-            if "geom" in column_datatypes:
-                assert output_geometrytype_calc is not None
-                column_datatypes["geom"] = output_geometrytype_calc.name
+        if output_geometrytype_calc is not None and "geom" in column_datatypes:
+            column_datatypes["geom"] = output_geometrytype_calc.name
+        output_geometrytype_append = (
+            force_output_geometrytype if explode_append else None
+        )
 
         worker_type = _general_helper.worker_type_to_use(input1_layer.featurecount)
         logger.info(
@@ -3536,7 +3531,7 @@ def _two_layer_vector_operation(
                 # rename/move it as that is faster.
                 if (
                     not explodecollections
-                    and force_output_geometrytype is None
+                    and output_geometrytype_append is None
                     and where_post is None
                     and tmp_partial_output_path.suffix.lower()
                     == tmp_output_path.suffix.lower()
@@ -3566,7 +3561,7 @@ def _two_layer_vector_operation(
                         dst_layer=output_layer,
                         write_mode="append",
                         explodecollections=explode_append,
-                        force_output_geometrytype=force_output_geometrytype,
+                        force_output_geometrytype=output_geometrytype_append,
                         where=where_post,
                         create_spatial_index=create_spatial_index,
                         preserve_fid=False,

--- a/geofileops/util/_geoseries_util.py
+++ b/geofileops/util/_geoseries_util.py
@@ -43,7 +43,7 @@ def get_geometrytypes(
     geom_types_2D = input_geoseries[~input_geoseries.has_z].geom_type.unique()
     geom_types_2D = [gtype for gtype in geom_types_2D if gtype is not None]
     geom_types_3D = input_geoseries[input_geoseries.has_z].geom_type.unique()
-    geom_types_3D = ["3D " + gtype for gtype in geom_types_3D if gtype is not None]
+    geom_types_3D = [f"{gtype}Z" for gtype in geom_types_3D if gtype is not None]
     geom_types = geom_types_3D + geom_types_2D
 
     if len(geom_types) == 0:

--- a/geofileops/util/_sqlite_util.py
+++ b/geofileops/util/_sqlite_util.py
@@ -531,9 +531,8 @@ def copy_table(
         conn.execute(sql)
 
         # Determine the columns of the tables
-        if not preserve_fid:
-            column_filter = "WHERE lower(name) <> 'fid'"
-
+        # If the fid should not be preserved, don't include it in the column list
+        column_filter = "" if preserve_fid else "WHERE lower(name) <> 'fid'"
         sql = f"""
             SELECT name
               FROM pragma_table_info('{input_table}', 'input_db')

--- a/geofileops/util/_sqlite_util.py
+++ b/geofileops/util/_sqlite_util.py
@@ -549,11 +549,13 @@ def copy_table(
         # TODO: compare both to be sure they are identical?
         assert input_columns == output_columns
 
+        input_columns_str = ", ".join([f'"{col}"' for col in input_columns])
+        output_columns_str = ", ".join([f'"{col}"' for col in output_columns])
         where_clause = f"WHERE {where}" if where else ""
         sql = f"""
             INSERT INTO main."{output_table}"
-                ({",".join(output_columns)})
-            SELECT {",".join(output_columns)}
+                ({output_columns_str})
+            SELECT {input_columns_str}
               FROM input_db."{input_table}"
              {where_clause};
         """

--- a/geofileops/util/_sqlite_util.py
+++ b/geofileops/util/_sqlite_util.py
@@ -488,7 +488,9 @@ def copy_table(
     preserve_fid: bool = False,
     profile: SqliteProfile = SqliteProfile.DEFAULT,
 ) -> None:
-    """Append data to an existing table.
+    """Copy data from one to another table.
+
+    At the moment only appending to an existing table is supported.
 
     Args:
         input_path (PathLike): The path to the input SQLite database.

--- a/geofileops/util/_sqlite_util.py
+++ b/geofileops/util/_sqlite_util.py
@@ -546,9 +546,6 @@ def copy_table(
         """
         output_columns = sorted([value[0] for value in conn.execute(sql).fetchall()])
 
-        # TODO: compare both to be sure they are identical?
-        assert input_columns == output_columns
-
         input_columns_str = ", ".join([f'"{col}"' for col in input_columns])
         output_columns_str = ", ".join([f'"{col}"' for col in output_columns])
         where_clause = f"WHERE {where}" if where else ""

--- a/tests/general_file_layer_operations/test_geofile.py
+++ b/tests/general_file_layer_operations/test_geofile.py
@@ -831,23 +831,27 @@ def test_copy_layer_to_gpkg_zip(tmp_path):
 @pytest.mark.parametrize(
     "src",
     [
+        f"{test_helper.data_dir.as_posix()}/polygon-parcel.gpkg",
+        f"/vsicurl/{test_helper.data_url}/polygon-parcel.gpkg",
         f"/vsizip//vsicurl/{test_helper.data_url}/poly_shp.zip",
         f"/vsizip//vsicurl/{test_helper.data_url}/poly_shp.zip/poly.shp",
         f"/vsizip/{test_helper.data_dir.as_posix()}/poly_shp.zip",
         f"/vsizip/{test_helper.data_dir.as_posix()}/poly_shp.zip/poly.shp",
     ],
 )
-def test_copy_layer_vsi(tmp_path, src):
-    # Prepare test data
-    dst = tmp_path / "output.gpkg"
+def test_copy_layer_vsi(src):
+    dst = "/vsimem/output.gpkg"
 
-    # copy_layer with vsi
-    gfo.copy_layer(src, dst)
+    try:
+        # copy_layer with vsi
+        gfo.copy_layer(src, dst)
 
-    # Now compare source and dst file
-    src_layerinfo = gfo.get_layerinfo(src)
-    dst_layerinfo = gfo.get_layerinfo(dst)
-    assert src_layerinfo.featurecount == dst_layerinfo.featurecount
+        # Now compare source and dst file
+        src_layerinfo = gfo.get_layerinfo(src)
+        dst_layerinfo = gfo.get_layerinfo(dst)
+        assert src_layerinfo.featurecount == dst_layerinfo.featurecount
+    finally:
+        gdal.Unlink(dst)
 
 
 @pytest.mark.parametrize("suffix", SUFFIXES_FILEOPS)

--- a/tests/single_layer_operations/test_geofileops_singlelayer.py
+++ b/tests/single_layer_operations/test_geofileops_singlelayer.py
@@ -13,7 +13,7 @@ import shapely
 from shapely import MultiPolygon, Polygon
 
 from geofileops import GeometryType, fileops, geoops
-from geofileops._compat import SPATIALITE_GTE_51
+from geofileops._compat import GDAL_GTE_39, SPATIALITE_GTE_51
 from geofileops.util import _general_util, _geofileinfo, _geoops_sql, _geopath_util
 from geofileops.util._geofileinfo import GeofileInfo
 from tests import test_helper
@@ -197,6 +197,16 @@ def test_buffer_basic(
     dimensions,
 ):
     """Buffer basics are available both in the gpd and sql implementations."""
+    if (
+        not GDAL_GTE_39
+        and dimensions == "XYZ"
+        and suffix == ".gpkg"
+        and geoops_module != "_geoops_gpd"
+    ):
+        pytest.xfail(
+            "GDAL < 3.9 (at least) writes 3D geometries even though "
+            "force_geometrytype='MULTIPOLYGON' for buffer operation."
+        )
     # Prepare test data
     input_path = test_helper.get_testfile(
         testfile, suffix=suffix, epsg=epsg, empty=empty_input, dimensions=dimensions


### PR DESCRIPTION
Improve performance of `copy_layer` for appends from gpkg to gpkg. Because this is used to merge the results of all batches in all operations, this improves performance significantly for (almost) all operations when processing large files.

Can be disabled by defining configuration option `GFO_COPY_LAYER_SQLITE_DIRECT=0`.

Resolves #732