### PR TITLE
ENH: reduce commited memory being allocated

### DIFF
--- a/geofileops/util/_processing_util.py
+++ b/geofileops/util/_processing_util.py
@@ -91,6 +91,13 @@ def initialize_worker(worker_type: str):
             f"Invalid worker_type: {worker_type}. Must be one of {WORKER_TYPES}."
         )
 
+    # Reduce OpenMP threads to avoid unnecessary inflated committed memory when using
+    # multiprocessing.
+    # Should work for any numeric library used (openblas, mkl,...).
+    # Ref: https://stackoverflow.com/questions/77764228/pandas-scipy-high-commit-memory-usage-windows
+    if os.environ.get("OMP_NUM_THREADS") is None:
+        os.environ["OMP_NUM_THREADS"] = "1"
+
     # We don't want the workers to block the entire system, so make the workers nice
     # if they aren't quite nice already.
     #


### PR DESCRIPTION
Reason of the overallocation is apparenly a threadpool being created in the numeric library used in numpy.

This can me changed via the environment variable `OMP_NUM_THREADS`.

Reference: https://stackoverflow.com/questions/77764228/pandas-scipy-high-commit-memory-usage-windows