### PR TITLE
BUG: copy_layer should give an error if src_layer is not specified for multi-layer src files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 - Write gdal log files to `GFO_TMPDIR` if specified (#727)
 - Reduce memory being committed on hardware with many cores (#739, #717)
 
+### Bugs fixed
+
+- `copy_layer` should give an error if `src_layer` is not specified for multi-layer src
+  files (#745)
+
 ## 0.10.2 (2025-08-20)
 
 ### Improvements

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -2592,8 +2592,10 @@ def copy_layer(
         src (PathLike): The source path. |GDAL_vsi| paths are also supported.
         dst (PathLike): The destination path. |GDAL_vsi| paths can be used for handlers
             with write support.
-        src_layer (str, optional): The source layer. If None and there is only
-            one layer in the src file, that layer is taken. Defaults to None.
+        src_layer (str, optional): The source layer. If the source contains a single
+            layer, that layer will be taken if `src_layer` is None. If it contains
+            multiple layers, `src_layer` is mandatory unless `sql_stmt` is specified.
+            Defaults to None.
         dst_layer (str, optional): The destination layer. If None, the destination file
             stem is taken as layer name. Defaults to None.
         write_mode (str, optional): The write mode. Defaults to "create". Valid values:
@@ -2717,6 +2719,9 @@ def copy_layer(
         sql_stmt = _fill_out_sql_placeholders(
             path=src, layer=src_layer, sql_stmt=sql_stmt, columns=columns
         )
+    elif src_layer is None:
+        # If no sql_stmt is specified, the src file should have only one layer
+        src_layer = get_only_layer(src)
 
     if dst_layer is None:
         dst_layer = get_default_layer(dst)

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -527,7 +527,9 @@ def _get_only_layer(datasource: gdal.Dataset) -> ogr.Layer:
         if len(layers) == 1:
             return datasource.GetLayer(layers[0])
         else:
-            raise ValueError(f"input has > 1 layer, but no layer specified: {layers}")
+            raise ValueError(
+                f"input has > 1 layers: a layer must be specified: {layers}"
+            )
 
 
 def get_default_layer(path: Union[str, "os.PathLike[Any]"]) -> str:

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -2719,9 +2719,6 @@ def copy_layer(
         sql_stmt = _fill_out_sql_placeholders(
             path=src, layer=src_layer, sql_stmt=sql_stmt, columns=columns
         )
-    elif src_layer is None:
-        # If no sql_stmt is specified, the src file should have only one layer
-        src_layer = get_only_layer(src)
 
     if dst_layer is None:
         dst_layer = get_default_layer(dst)

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -769,7 +769,7 @@ def _validate_file(
                     f"{path=}"
                 )
 
-    except Exception as ex:
+    except Exception as ex:  # pragma: no cover
         # In gdal 3.10, invalid gpkg files are still written when an invalid sql
         # is used if a new file is created or an existing one is overwritten.
         logger.warning(

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -567,11 +567,10 @@ def vector_translate(
             # detect this case later on, check here if the input file already has an
             # attribute column "geometry".
             if input_layers is None or len(input_layers) == 1:
-                input_layer = input_layers[0] if input_layers is not None else None
-                if input_layer is None:
+                if input_layers is None:
                     datasource_layer = input_ds.GetLayer()
                 else:
-                    datasource_layer = input_ds.GetLayerByName(input_layer)
+                    datasource_layer = input_ds.GetLayerByName(input_layers[0])
                 layer_defn = datasource_layer.GetLayerDefn()
                 for field in range(layer_defn.GetFieldCount()):
                     field_name_lower = layer_defn.GetFieldDefn(field).GetName().lower()

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -344,8 +344,10 @@ def vector_translate(
         # If a sql statement is passed, the input layers are not relevant,
         # and ogr2ogr will give a warning, so clear it.
         input_layers = None
-    if input_layers is not None and isinstance(input_layers, str):
+    if isinstance(input_layers, str):
         input_layers = [input_layers]
+    elif isinstance(input_layers, list) and len(input_layers) == 0:
+        input_layers = None
 
     # SRS
     if input_srs is not None and isinstance(input_srs, int):
@@ -518,6 +520,17 @@ def vector_translate(
 
                 raise
 
+            # if sql_stmt is None, input_layers must be specified if the input file has
+            # multiple layers.
+            if sql_stmt is None and input_layers is None:
+                nb_layers = input_ds.GetLayerCount()
+                if nb_layers == 1:
+                    input_layers = [input_ds.GetLayer(0).GetName()]
+                elif nb_layers > 1:
+                    raise ValueError(
+                        f"input has > 1 layer, but no layer specified: {input_path}"
+                    )
+
             # If output_srs is not specified and the result has 0 rows, gdal creates the
             # output file without srs.
             # documented in https://github.com/geofileops/geofileops/issues/313
@@ -553,14 +566,19 @@ def vector_translate(
             # creates an attribute column "geometry" in the output file. To be able to
             # detect this case later on, check here if the input file already has an
             # attribute column "geometry".
-            input_layer = input_ds.GetLayer()
-            layer_defn = input_layer.GetLayerDefn()
-            for field_idx in range(layer_defn.GetFieldCount()):
-                field_name_lower = layer_defn.GetFieldDefn(field_idx).GetName().lower()
-                if field_name_lower == "geom":
-                    input_has_geom_attribute = True
-                elif field_name_lower == "geometry":
-                    input_has_geometry_attribute = True
+            if input_layers is None or len(input_layers) == 1:
+                input_layer = input_layers[0] if input_layers is not None else None
+                if input_layer is None:
+                    datasource_layer = input_ds.GetLayer()
+                else:
+                    datasource_layer = input_ds.GetLayerByName(input_layer)
+                layer_defn = datasource_layer.GetLayerDefn()
+                for field in range(layer_defn.GetFieldCount()):
+                    field_name_lower = layer_defn.GetFieldDefn(field).GetName().lower()
+                    if field_name_lower == "geom":
+                        input_has_geom_attribute = True
+                    elif field_name_lower == "geometry":
+                        input_has_geometry_attribute = True
 
             # Consolidate all parameters
             # First take copy of args, because gdal.VectorTranslateOptions adds all
@@ -604,6 +622,8 @@ def vector_translate(
             raise RuntimeError("output_ds is None")
 
     except FileNotFoundError:
+        raise
+    except ValueError:
         raise
     except Exception as ex:
         output_ds = None

--- a/geofileops/util/_ogr_util.py
+++ b/geofileops/util/_ogr_util.py
@@ -528,7 +528,7 @@ def vector_translate(
                     input_layers = [input_ds.GetLayer(0).GetName()]
                 elif nb_layers > 1:
                     raise ValueError(
-                        f"input has > 1 layer, but no layer specified: {input_path}"
+                        f"input has > 1 layers: a layer must be specified: {input_path}"
                     )
 
             # If output_srs is not specified and the result has 0 rows, gdal creates the

--- a/tests/general_file_layer_operations/test_geofile.py
+++ b/tests/general_file_layer_operations/test_geofile.py
@@ -648,7 +648,7 @@ def test_copy_layer_force_output_geometrytype(tmp_path, testfile, force_geometry
         (
             {"src": test_helper.get_testfile("polygon-twolayers")},
             ValueError,
-            "input has > 1 layer, but no layer specified",
+            "input has > 1 layers: a layer must be specified",
         ),
     ],
 )
@@ -1248,7 +1248,9 @@ def test_get_layerinfo_twolayers():
     assert len(layerinfo.columns) == 1
 
     # Test error if no layer specified
-    with pytest.raises(ValueError, match="input has > 1 layer, but no layer specified"):
+    with pytest.raises(
+        ValueError, match="input has > 1 layers: a layer must be specified"
+    ):
         layerinfo = gfo.get_layerinfo(src)
 
 
@@ -1280,7 +1282,9 @@ def test_get_only_layer_two_layers():
     src = test_helper.get_testfile("polygon-twolayers")
     layers = gfo.listlayers(src)
     assert len(layers) == 2
-    with pytest.raises(ValueError, match="input has > 1 layer, but no layer specified"):
+    with pytest.raises(
+        ValueError, match="input has > 1 layers: a layer must be specified"
+    ):
         _ = gfo.get_only_layer(src)
 
 
@@ -1820,7 +1824,7 @@ def test_fill_out_sql_placeholders():
         (
             None,
             'SELECT * FROM "{input_layer}"',
-            "input has > 1 layer, but no layer specified",
+            "input has > 1 layers: a layer must be specified",
         ),
     ],
 )

--- a/tests/general_file_layer_operations/test_geofile.py
+++ b/tests/general_file_layer_operations/test_geofile.py
@@ -645,6 +645,11 @@ def test_copy_layer_force_output_geometrytype(tmp_path, testfile, force_geometry
             ValueError,
             "append parameter is deprecated, use write_mode",
         ),
+        (
+            {"src": test_helper.get_testfile("polygon-twolayers")},
+            ValueError,
+            "input has > 1 layer, but no layer specified",
+        ),
     ],
 )
 def test_copy_layer_errors(tmp_path, kwargs, exp_ex, exp_error):
@@ -826,6 +831,26 @@ def test_copy_layer_to_gpkg_zip(tmp_path):
     src_gdf = gfo.read_file(src)
     dst_gdf = gfo.read_file(dst)
     assert_geodataframe_equal(src_gdf, dst_gdf)
+
+
+def test_copy_layer_twolayers(tmp_path):
+    src = test_helper.get_testfile("polygon-twolayers")
+
+    # Test first layer
+    dst_parcels = tmp_path / "output_parcels.gpkg"
+    gfo.copy_layer(src, dst_parcels, src_layer="parcels")
+    layerinfo_parcels = gfo.get_layerinfo(dst_parcels)
+    assert layerinfo_parcels.featurecount == 48
+    assert layerinfo_parcels.name == "output_parcels"
+    assert len(layerinfo_parcels.columns) == 11
+
+    # Test second layer
+    dst_zones = tmp_path / "output_zones.gpkg"
+    gfo.copy_layer(src, dst_zones, src_layer="zones")
+    layerinfo_zones = gfo.get_layerinfo(dst_zones)
+    assert layerinfo_zones.featurecount == 5
+    assert layerinfo_zones.name == "output_zones"
+    assert len(layerinfo_zones.columns) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/util/test_ogr_util.py
+++ b/tests/util/test_ogr_util.py
@@ -209,7 +209,9 @@ def test_vector_translate_input_multilayer_error(tmp_path):
     input_path = test_helper.get_testfile("polygon-twolayers")
 
     output_path = tmp_path / "output.gpkg"
-    with pytest.raises(ValueError, match="input has > 1 layer, but no layer specified"):
+    with pytest.raises(
+        ValueError, match="input has > 1 layers: a layer must be specified"
+    ):
         _ogr_util.vector_translate(str(input_path), output_path)
 
 

--- a/tests/util/test_ogr_util.py
+++ b/tests/util/test_ogr_util.py
@@ -205,6 +205,14 @@ def test_vector_translate_geometrytype_error(tmp_path, output_geometrytype, exp_
         )
 
 
+def test_vector_translate_input_multilayer_error(tmp_path):
+    input_path = test_helper.get_testfile("polygon-twolayers")
+
+    output_path = tmp_path / "output.gpkg"
+    with pytest.raises(ValueError, match="input has > 1 layer, but no layer specified"):
+        _ogr_util.vector_translate(str(input_path), output_path)
+
+
 def test_vector_translate_input_nolayer(tmp_path):
     input_path = test_helper.get_testfile("polygon-parcel", dst_dir=tmp_path)
     output_path = tmp_path / f"output{input_path.suffix}"


### PR DESCRIPTION
Now it does the default behaviour of gdal.VectorTranslate, which is apparently to just take the first layer encountered.