### PR TITLE
MAINT: drop support for libspatialite 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.11.0 (yyyy-mm-dd)
 
+### Deprecations and compatibility notes
+
+- Minimum version of dependencies updated to spatialite 5.1.
+
 ### Improvements
 
 - Improve performance of clip with a complex clip layer (#740)

--- a/ci/envs/latest-fiona.yml
+++ b/ci/envs/latest-fiona.yml
@@ -8,7 +8,7 @@ dependencies:
   - cloudpickle
   - gdal >=3.6.3
   - geopandas-base >=0.12
-  - libspatialite >=5.0
+  - libspatialite
   # - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy
   - packaging

--- a/ci/envs/latest.yml
+++ b/ci/envs/latest.yml
@@ -9,7 +9,7 @@ dependencies:
   - cloudpickle
   - gdal >=3.6.3
   - geopandas-base >=0.12
-  - libspatialite >=5.0
+  - libspatialite
   # - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy
   - packaging

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -8,7 +8,7 @@ dependencies:
   - cloudpickle
   - gdal =3.7  # 3.7.0 released 2023-05-03
   - geopandas-base =0.13  # first released 2023-05-06
-  - libspatialite =5.0  #  knn index replaced by knn2 in 5.1
+  - libspatialite =5.1  #  released 2023-08-04
   - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy =1.22  # released 2021-12-31
   - packaging

--- a/ci/envs/readthedocs.yml
+++ b/ci/envs/readthedocs.yml
@@ -7,7 +7,7 @@ dependencies:
   - cloudpickle
   - gdal >=3.6.3
   - geopandas-base >=0.12
-  - libspatialite >=5.0
+  - libspatialite
   - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy
   - packaging

--- a/geofileops/_compat.py
+++ b/geofileops/_compat.py
@@ -27,4 +27,3 @@ SHAPELY_GTE_20 = version.parse(shapely.__version__) >= version.parse("2")
 
 sqlite3_spatialite_version_info = _sqlite_util.spatialite_version_info()
 sqlite3_spatialite_version = sqlite3_spatialite_version_info["spatialite_version"]
-SPATIALITE_GTE_51 = version.parse(sqlite3_spatialite_version) >= version.parse("5.1")

--- a/geofileops/geoops.py
+++ b/geofileops/geoops.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any, Literal, Union
 from pygeoops import GeometryType
 
 from geofileops import fileops
-from geofileops._compat import SPATIALITE_GTE_51
 from geofileops.helpers._configoptions_helper import ConfigOptions
 from geofileops.util import (
     _geofileinfo,
@@ -1452,7 +1451,7 @@ def makevalid(
             stacklevel=2,
         )
 
-    if SPATIALITE_GTE_51 and gridsize == 0.0:
+    if gridsize == 0.0:
         # If spatialite >= 5.1 available use faster/less memory using SQL implementation
         # Only use this version if gridsize is 0.0, because when gridsize applied it is
         # less robust than the gpd implementation.

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -22,7 +22,6 @@ import pandas as pd
 
 import geofileops as gfo
 from geofileops import GeometryType, LayerInfo, PrimitiveType, fileops
-from geofileops._compat import SPATIALITE_GTE_51
 from geofileops.helpers import _general_helper, _parameter_helper
 from geofileops.helpers._configoptions_helper import ConfigOptions
 from geofileops.util import (
@@ -329,27 +328,14 @@ def makevalid(
     # ----------------------------------------------
     # Only apply makevalid if the geometry is truly invalid, this is faster.
     # GEOSMakeValid crashes with EMPTY input, so check this first.
-    if SPATIALITE_GTE_51:
-        operation = """
-            IIF({geometrycolumn} IS NULL OR ST_IsEmpty({geometrycolumn}) <> 0,
-                NULL,
-                IIF(ST_IsValid({geometrycolumn}) = 1,
-                    {geometrycolumn},
-                    GEOSMakeValid({geometrycolumn}, 0)
-               )
-            )"""
-    else:
-        # Prepare sql template for this operation
-        operation = """
+    operation = """
+        IIF({geometrycolumn} IS NULL OR ST_IsEmpty({geometrycolumn}) <> 0,
+            NULL,
             IIF(ST_IsValid({geometrycolumn}) = 1,
                 {geometrycolumn},
-                ST_MakeValid({geometrycolumn})
-            )"""
-
-        # If we want a specific geometrytype, only extract the relevant type
-        if force_output_geometrytype is not GeometryType.GEOMETRYCOLLECTION:
-            primitivetypeid = force_output_geometrytype.to_primitivetype.value  # type: ignore[union-attr]
-            operation = f"ST_CollectionExtract({operation}, {primitivetypeid})"
+                GEOSMakeValid({geometrycolumn}, 0)
+            )
+        )"""
 
     # Now we can prepare the entire statement
     sql_template = f"""
@@ -2393,15 +2379,11 @@ def join_nearest(
     if input2_layer is None:
         input2_layer = gfo.get_only_layer(input2_path)
 
-    # If spatialite >= 5.1, check some more parameters
-    if SPATIALITE_GTE_51:
-        if distance is None:
-            raise ValueError("distance is mandatory with spatialite >= 5.1")
-        if expand is None:
-            raise ValueError("expand is mandatory with spatialite >= 5.1")
-        expand_int = 1 if expand else False
-    elif expand is not None and not expand:
-        raise ValueError("expand=False is not supported with spatialite < 5.1")
+    if distance is None:
+        raise ValueError("distance is mandatory with spatialite >= 5.1")
+    if expand is None:
+        raise ValueError("expand is mandatory with spatialite >= 5.1")
+    expand_int = 1 if expand else False
 
     # Prepare input files
     # To use knn index, the input layers need to be in sqlite file format
@@ -2438,43 +2420,26 @@ def join_nearest(
         )
 
     # Remark: the 2 input layers need to be in one file!
-    if SPATIALITE_GTE_51:
-        sql_template = f"""
-            SELECT layer1.{{input1_geometrycolumn}} as geom
-                  {{layer1_columns_prefix_alias_str}}
-                  {{layer2_columns_prefix_alias_str}}
-                  ,k.pos
-                  ,ST_Distance(
-                    layer1.{{input1_geometrycolumn}}, layer2.{{input2_geometrycolumn}}
-                  ) AS distance
-                  ,k.distance_crs
-              FROM "{{input1_layer}}" layer1
-              JOIN knn2 k
-              JOIN "{{input2_layer}}" layer2 ON layer2.rowid = k.fid
-             WHERE f_table_name = '{{input2_layer}}'
-               AND f_geometry_column = '{{input2_geometrycolumn}}'
-               AND ref_geometry = ST_Centroid(layer1.{{input1_geometrycolumn}})
-               AND radius = {distance}
-               AND max_items = {nb_nearest}
-               AND expand = {expand_int}
-               {{batch_filter}}
-        """
-    else:
-        sql_template = f"""
-            SELECT layer1.{{input1_geometrycolumn}} as geom
-                  {{layer1_columns_prefix_alias_str}}
-                  {{layer2_columns_prefix_alias_str}}
-                  ,k.pos, k.distance
-              FROM {{input1_databasename}}."{{input1_layer}}" layer1
-              JOIN {{input2_databasename}}.knn k
-              JOIN {{input2_databasename}}."{{input2_layer}}" layer2
-                ON layer2.rowid = k.fid
-             WHERE k.f_table_name = '{{input2_layer}}'
-               AND k.f_geometry_column = '{{input2_geometrycolumn}}'
-               AND k.ref_geometry = layer1.{{input1_geometrycolumn}}
-               AND k.max_items = {nb_nearest}
-               {{batch_filter}}
-        """
+    sql_template = f"""
+        SELECT layer1.{{input1_geometrycolumn}} as geom
+                {{layer1_columns_prefix_alias_str}}
+                {{layer2_columns_prefix_alias_str}}
+                ,k.pos
+                ,ST_Distance(
+                layer1.{{input1_geometrycolumn}}, layer2.{{input2_geometrycolumn}}
+                ) AS distance
+                ,k.distance_crs
+            FROM "{{input1_layer}}" layer1
+            JOIN knn2 k
+            JOIN "{{input2_layer}}" layer2 ON layer2.rowid = k.fid
+            WHERE f_table_name = '{{input2_layer}}'
+            AND f_geometry_column = '{{input2_geometrycolumn}}'
+            AND ref_geometry = ST_Centroid(layer1.{{input1_geometrycolumn}})
+            AND radius = {distance}
+            AND max_items = {nb_nearest}
+            AND expand = {expand_int}
+            {{batch_filter}}
+    """
 
     return _two_layer_vector_operation(
         input1_path=input1_tmp_path,
@@ -3398,27 +3363,20 @@ def _two_layer_vector_operation(
 
         # Apply gridsize if it is specified
         if gridsize != 0.0:
-            if SPATIALITE_GTE_51:
-                # Spatialite >= 5.1 available, so we can try ST_ReducePrecision first,
-                # which should be faster.
-                # ST_ReducePrecision seems to crash on EMPTY geometry, so check
-                # ST_IsEmpty not being 0 (result can be -1, 0 or 1).
-                gridsize_op = f"""
-                    IIF(sub_gridsize.geom IS NULL OR ST_IsEmpty(sub_gridsize.geom) <> 0,
-                        NULL,
-                        IFNULL(
-                            ST_ReducePrecision(sub_gridsize.geom, {gridsize}),
-                            ST_GeomFromWKB(GFO_ReducePrecision(
-                                ST_AsBinary(sub_gridsize.geom), {gridsize}
-                            ))
-                        )
+            # Try ST_ReducePrecision first, which should be faster.
+            # ST_ReducePrecision seems to crash on EMPTY geometry, so check
+            # ST_IsEmpty not being 0 (result can be -1, 0 or 1).
+            gridsize_op = f"""
+                IIF(sub_gridsize.geom IS NULL OR ST_IsEmpty(sub_gridsize.geom) <> 0,
+                    NULL,
+                    IFNULL(
+                        ST_ReducePrecision(sub_gridsize.geom, {gridsize}),
+                        ST_GeomFromWKB(GFO_ReducePrecision(
+                            ST_AsBinary(sub_gridsize.geom), {gridsize}
+                        ))
                     )
-                """
-            else:
-                gridsize_op = (
-                    "ST_GeomFromWKB(GFO_ReducePrecision("
-                    f"ST_AsBinary(sub_gridsize.geom), {gridsize}))"
                 )
+            """
 
             # All columns need to be specified
             # Remark:
@@ -4407,38 +4365,19 @@ def dissolve_singlethread(
 def _format_apply_gridsize_operation(
     geometrycolumn: str, gridsize: float, force_output_geometrytype: GeometryType
 ) -> str:
-    if SPATIALITE_GTE_51:
-        # ST_ReducePrecision and GeosMakeValid only available for spatialite >= 5.1
-        # Retry with applying makevalid.
-        # It is not possible to return the original geometry if error stays after
-        # makevalid, because spatialite functions return NULL for failures as well as
-        # when the result is correctly NULL, so not possible to make the distinction.
-        # ST_ReducePrecision seems to crash on EMPTY geometry, so check ST_IsEmpty not
-        # being 0 (result can be -1, 0 or 1).
-        gridsize_op = f"""
-            IIF({geometrycolumn} IS NULL OR ST_IsEmpty({geometrycolumn}) <> 0,
-                NULL,
-                IFNULL(
-                    ST_ReducePrecision({geometrycolumn}, {gridsize}),
-                    ST_ReducePrecision(GeosMakeValid({geometrycolumn}, 0), {gridsize})
-                )
+    # It is not possible to return the original geometry if error stays after
+    # makevalid, because spatialite functions return NULL for failures as well as
+    # when the result is correctly NULL, so not possible to make the distinction.
+    # ST_ReducePrecision seems to crash on EMPTY geometry, so check ST_IsEmpty not
+    # being 0 (result can be -1, 0 or 1).
+    gridsize_op = f"""
+        IIF({geometrycolumn} IS NULL OR ST_IsEmpty({geometrycolumn}) <> 0,
+            NULL,
+            IFNULL(
+                ST_ReducePrecision({geometrycolumn}, {gridsize}),
+                ST_ReducePrecision(GeosMakeValid({geometrycolumn}, 0), {gridsize})
             )
-        """
-    else:
-        # Apply snaptogrid, but this results in invalid geometries, so also
-        # Makevalid.
-        gridsize_op = f"ST_MakeValid(SnapToGrid({geometrycolumn}, {gridsize}))"
-
-        # SnapToGrid + ST_MakeValid can result in collapsed (pieces of)
-        # geometries, so finally apply collectionextract as well.
-        if force_output_geometrytype is None:
-            warnings.warn(
-                "a gridsize is specified but no force_output_geometrytype, "
-                "this can result in inconsistent geometries in the output",
-                stacklevel=3,
-            )
-        else:
-            primitivetypeid = force_output_geometrytype.to_primitivetype.value
-            gridsize_op = f"ST_CollectionExtract({gridsize_op}, {primitivetypeid})"
+        )
+    """
 
     return gridsize_op

--- a/tests/single_layer_operations/test_geofileops_singlelayer.py
+++ b/tests/single_layer_operations/test_geofileops_singlelayer.py
@@ -13,7 +13,7 @@ import shapely
 from shapely import MultiPolygon, Polygon
 
 from geofileops import GeometryType, fileops, geoops
-from geofileops._compat import GDAL_GTE_39, SPATIALITE_GTE_51
+from geofileops._compat import GDAL_GTE_39
 from geofileops.util import _general_util, _geofileinfo, _geoops_sql, _geopath_util
 from geofileops.util._geofileinfo import GeofileInfo
 from tests import test_helper
@@ -958,11 +958,7 @@ def test_makevalid_gridsize(tmp_path, geoops_module, gridsize, keep_empty_geoms)
         expected_featurecount -= 1
         # With gridsize specified, a sliver polygon is removed as well
         if gridsize > 0.0:
-            # If sql based and spatialite < 5.1, the sliver isn't cleaned up...
-            if not (
-                not SPATIALITE_GTE_51 and geoops_module == "geofileops.util._geoops_sql"
-            ):
-                expected_featurecount -= 1
+            expected_featurecount -= 1
 
     set_geoops_module(geoops_module)
 

--- a/tests/test_spatialite.py
+++ b/tests/test_spatialite.py
@@ -7,27 +7,23 @@ import shapely.geometry as sh_geom
 from packaging import version
 
 import geofileops as gfo
-from geofileops._compat import SPATIALITE_GTE_51
 from tests import test_helper
 
 
 @pytest.mark.parametrize(
-    "descr, sql, version_needed",
+    "descr, sql",
     [
         (
             "1_geos_basic",
             "SELECT ST_Buffer(ST_GeomFromText('POINT (5 5)'), 5) AS geom",
-            "5.0",
         ),
         (
             "2_geos_advanced",
             "SELECT ST_ConcaveHull(ST_GeomFromText('POINT (5 5)')) geom",
-            "5.0",
         ),
         (
             "3_geos_3100",
             "SELECT GeosMakeValid(ST_GeomFromText('POINT (5 5)')) AS geom",
-            "5.1",
         ),
         (
             "4_geos_3110",
@@ -38,21 +34,13 @@ from tests import test_helper
                        5
                    ) AS geom
             """,
-            "5.1",
         ),
     ],
 )
-def test_geos_functions(descr, sql, version_needed):
-    """Test some geos functions from different spatialite versions."""
+def test_geos_functions(descr, sql):
+    """Test some geos functions available via spatialite."""
     test_path = test_helper.get_testfile(testfile="polygon-parcel")
-
-    if version.parse(version_needed) < version.parse("5.1") or (
-        version.parse(version_needed) >= version.parse("5.1") and SPATIALITE_GTE_51
-    ):
-        gfo.read_file(test_path, sql_stmt=sql)
-    else:
-        with pytest.raises(Exception, match="no such function"):
-            gfo.read_file(test_path, sql_stmt=sql)
+    gfo.read_file(test_path, sql_stmt=sql)
 
 
 @pytest.mark.skipif(

--- a/tests/test_spatialite.py
+++ b/tests/test_spatialite.py
@@ -4,7 +4,6 @@ Tests for functionalities in ogr_util.
 
 import pytest
 import shapely.geometry as sh_geom
-from packaging import version
 
 import geofileops as gfo
 from tests import test_helper


### PR DESCRIPTION
Support can be dropped:
- is old enough now (5.1 was released 2023-04-08
- newer versions of GDAL aren't compatible with it anymore either
- nice code and test cleanup/simplification