### PR TITLE
CI: pin CI tests to pandas <3.0

### DIFF
--- a/ci/envs/latest-fiona.yml
+++ b/ci/envs/latest-fiona.yml
@@ -12,7 +12,7 @@ dependencies:
   # - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy
   - packaging
-  - pandas
+  - pandas <3
   - psutil
   - pygeoops
   - pyogrio

--- a/ci/envs/latest.yml
+++ b/ci/envs/latest.yml
@@ -1,7 +1,6 @@
 name: geofileops-latest
 channels:
   - conda-forge
-  - conda-forge/label/python_rc
 dependencies:
   - python
   - pip
@@ -13,7 +12,7 @@ dependencies:
   # - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy
   - packaging
-  - pandas
+  - pandas <3
   - psutil
   - pygeoops
   - pyogrio


### PR DESCRIPTION
In the package dependencies (pip and conda) the dependency is properly set to < 3.0, but not yet in the CI env files.