### PR TITLE
BUG: fix writing csv files on non-UTF8 systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 - Fix `dissolve` on an input file without crs (#794)
+- Fix writing csv files on non-UTF8 systems (#797)
 
 ## 0.11.0 (2025-12-10)
 


### PR DESCRIPTION
When arrow is used to write data with special characters to a text file like .csv file, the preferred encoding of the OS is ignored and is always written as UTF-8... leading to an invalid file.

This PR disables use of arrow for .csv output files if the preferred encoding is not UTF-8.