### PR TITLE
ENH: Add support for pandas 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.11.1 (????-??-??)
 
+### Improvements
+
+- Small fix to support pandas 3.0 (#798)
+
 ### Bugs fixed
 
 - Fix `dissolve` on an input file without crs (#794)

--- a/ci/envs/latest-fiona.yml
+++ b/ci/envs/latest-fiona.yml
@@ -12,7 +12,7 @@ dependencies:
   # - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy
   - packaging
-  - pandas <3
+  - pandas
   - psutil
   - pygeoops
   - pyogrio

--- a/ci/envs/latest.yml
+++ b/ci/envs/latest.yml
@@ -12,7 +12,7 @@ dependencies:
   # - nomkl  # Use openblas instead of mkl saves 600 MB. Linux OK, 50% slower on Windows and OSX!
   - numpy
   - packaging
-  - pandas <3
+  - pandas
   - psutil
   - pygeoops
   - pyogrio

--- a/geofileops/_compat.py
+++ b/geofileops/_compat.py
@@ -29,6 +29,7 @@ GEOS_GTE_313 = version.parse(shapely.geos_version_string) >= version.parse("3.13
 
 PANDAS_GTE_20 = version.parse(pd.__version__) >= version.parse("2.0")
 PANDAS_GTE_22 = version.parse(pd.__version__) >= version.parse("2.2")
+PANDAS_GTE_30 = version.parse(pd.__version__) >= version.parse("3.0")
 
 PYOGRIO_GTE_010 = version.parse(pyogrio.__version__) >= version.parse("0.10")
 PYOGRIO_GTE_011 = version.parse(pyogrio.__version__) >= version.parse("0.11")

--- a/geofileops/util/_geoseries_util.py
+++ b/geofileops/util/_geoseries_util.py
@@ -41,9 +41,9 @@ def get_geometrytypes(
     else:
         input_geoseries = geoseries
     geom_types_2D = input_geoseries[~input_geoseries.has_z].geom_type.unique()
-    geom_types_2D = [gtype for gtype in geom_types_2D if gtype is not None]
+    geom_types_2D = [gtype for gtype in geom_types_2D if pd.notna(gtype)]
     geom_types_3D = input_geoseries[input_geoseries.has_z].geom_type.unique()
-    geom_types_3D = [f"{gtype}Z" for gtype in geom_types_3D if gtype is not None]
+    geom_types_3D = [f"{gtype}Z" for gtype in geom_types_3D if pd.notna(gtype)]
     geom_types = geom_types_3D + geom_types_2D
 
     if len(geom_types) == 0:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         "geopandas>=0.13",
         "numpy",
         "packaging",
-        "pandas>=1.5,<3.0",
+        "pandas>=1.5",
         "psutil",
         "pyarrow",
         "pygeoops>=0.4",

--- a/tests/general_file_layer_operations/test_geofile.py
+++ b/tests/general_file_layer_operations/test_geofile.py
@@ -1895,7 +1895,18 @@ def test_read_file(suffix, dimensions, engine_setter):  # noqa: ARG001
         (["OIDN", "GEWASGROEP", "lengte"], "IGNORE"),
     ],
 )
-def test_read_file_columns_geometry(tmp_path, suffix, columns, geometry, engine_setter):  # noqa: ARG001
+def test_read_file_columns_geometry(tmp_path, suffix, columns, geometry, engine_setter):
+    if (
+        engine_setter == "pyogrio"
+        and geometry == "NO"
+        and suffix == ".gpkg"
+        and PANDAS_GTE_30
+    ):
+        pytest.xfail(
+            "pyogrio without arrow gives an issue writing GPKG without geometry with "
+            "pandas >= 3"
+        )
+
     # Prepare test data
     # For multi-layer filetype, use 2-layer file for better test coverage
     src_info = _geofileinfo.get_geofileinfo(suffix)

--- a/tests/general_file_layer_operations/test_geofile.py
+++ b/tests/general_file_layer_operations/test_geofile.py
@@ -10,6 +10,7 @@ from itertools import product
 from pathlib import Path
 
 import geopandas as gpd
+import numpy as np
 import pandas as pd
 import pytest
 import shapely.geometry as sh_geom
@@ -24,6 +25,7 @@ from geofileops._compat import (
     GDAL_GTE_311,
     PANDAS_GTE_20,
     PANDAS_GTE_22,
+    PANDAS_GTE_30,
     PYOGRIO_GTE_010,
     PYOGRIO_GTE_011,
     PYOGRIO_GTE_012,
@@ -1493,7 +1495,10 @@ def test_get_layer_geometrytypes(suffix):
     src = test_helper.get_testfile("polygon-parcel", suffix=suffix)
     geometrytypes = gfo.get_layer_geometrytypes(str(src))
     if suffix == ".shp":
-        assert geometrytypes == ["POLYGON", "MULTIPOLYGON", None]
+        if PANDAS_GTE_30:
+            assert geometrytypes == ["POLYGON", "MULTIPOLYGON", np.nan]
+        else:
+            assert geometrytypes == ["POLYGON", "MULTIPOLYGON", None]
     else:
         assert geometrytypes == ["POLYGON", "MULTIPOLYGON"]
 

--- a/tests/multi_layer_operations/test_geofileops_twolayers.py
+++ b/tests/multi_layer_operations/test_geofileops_twolayers.py
@@ -1,6 +1,4 @@
-"""
-Tests for operations that are executed using a sql statement on two layers.
-"""
+"""Tests for operations that are executed using a sql statement on two layers."""
 
 import math
 import os
@@ -17,7 +15,12 @@ import shapely.geometry as sh_geom
 
 import geofileops as gfo
 from geofileops import GeometryType
-from geofileops._compat import GDAL_GTE_311, GEOPANDAS_110, GEOPANDAS_GTE_10
+from geofileops._compat import (
+    GDAL_GTE_311,
+    GEOPANDAS_110,
+    GEOPANDAS_GTE_10,
+    PANDAS_GTE_30,
+)
 from geofileops.util import _general_util, _geofileinfo, _sqlite_util
 from geofileops.util import _geoops_sql as geoops_sql
 from geofileops.util._geofileinfo import GeofileInfo
@@ -529,8 +532,9 @@ def test_identity(tmp_path, suffix, epsg, gridsize, subdivide_coords, fid_column
     renames = dict(zip(exp_gdf.columns, output_gdf.columns, strict=True))
     exp_gdf = exp_gdf.rename(columns=renames)
     # For text columns, gfo gives None rather than np.nan for missing values.
-    for column in exp_gdf.select_dtypes(include="O").columns:
-        exp_gdf[column] = exp_gdf[column].replace({np.nan: None})
+    if not PANDAS_GTE_30:
+        for column in exp_gdf.select_dtypes(include="O").columns:
+            exp_gdf[column] = exp_gdf[column].replace({np.nan: None})
     if gridsize != 0.0:
         exp_gdf.geometry = shapely.set_precision(exp_gdf.geometry, grid_size=gridsize)
     # Remove rows where geometry is empty or None

--- a/tests/multi_layer_operations/test_geofileops_twolayers.py
+++ b/tests/multi_layer_operations/test_geofileops_twolayers.py
@@ -2076,8 +2076,9 @@ def test_symmetric_difference(
     renames = dict(zip(exp_gdf.columns, output_gdf.columns, strict=True))
     exp_gdf = exp_gdf.rename(columns=renames)
     # For text columns, gfo gives None rather than np.nan for missing values.
-    for column in exp_gdf.select_dtypes(include="O").columns:
-        exp_gdf[column] = exp_gdf[column].replace({np.nan: None})
+    if not PANDAS_GTE_30:
+        for column in exp_gdf.select_dtypes(include="O").columns:
+            exp_gdf[column] = exp_gdf[column].replace({np.nan: None})
     if gridsize != 0.0:
         exp_gdf.geometry = shapely.set_precision(exp_gdf.geometry, grid_size=gridsize)
     # Remove rows where geometry is empty or None

--- a/tests/multi_layer_operations/test_geofileops_twolayers.py
+++ b/tests/multi_layer_operations/test_geofileops_twolayers.py
@@ -2264,8 +2264,9 @@ def test_union(
     renames = dict(zip(exp_gdf.columns, output_gdf.columns, strict=True))
     exp_gdf = exp_gdf.rename(columns=renames)
     # For text columns, gfo gives None rather than np.nan for missing values.
-    for column in exp_gdf.select_dtypes(include="O").columns:
-        exp_gdf[column] = exp_gdf[column].replace({np.nan: None})
+    if not PANDAS_GTE_30:
+        for column in exp_gdf.select_dtypes(include="O").columns:
+            exp_gdf[column] = exp_gdf[column].replace({np.nan: None})
     if gridsize != 0.0:
         exp_gdf.geometry = shapely.set_precision(exp_gdf.geometry, grid_size=gridsize)
     if explodecollections:
@@ -2337,8 +2338,9 @@ def test_union_circles(tmp_path, suffix, epsg):
     renames = dict(zip(exp_gdf.columns, output_gdf.columns, strict=True))
     exp_gdf = exp_gdf.rename(columns=renames)
     # For text columns, gfo gives None rather than np.nan for missing values.
-    for column in exp_gdf.select_dtypes(include="O").columns:
-        exp_gdf[column] = exp_gdf[column].replace({np.nan: None})
+    if not PANDAS_GTE_30:
+        for column in exp_gdf.select_dtypes(include="O").columns:
+            exp_gdf[column] = exp_gdf[column].replace({np.nan: None})
 
     assert_geodataframe_equal(
         output_gdf,
@@ -2395,8 +2397,9 @@ def test_union_circles(tmp_path, suffix, epsg):
     renames = dict(zip(exp_gdf.columns, output_gdf.columns, strict=True))
     exp_gdf = exp_gdf.rename(columns=renames)
     # For text columns, gfo gives None rather than np.nan for missing values.
-    for column in exp_gdf.select_dtypes(include="O").columns:
-        exp_gdf[column] = exp_gdf[column].replace({np.nan: None})
+    if not PANDAS_GTE_30:
+        for column in exp_gdf.select_dtypes(include="O").columns:
+            exp_gdf[column] = exp_gdf[column].replace({np.nan: None})
 
     assert_geodataframe_equal(
         output_gdf,


### PR DESCRIPTION
Small change in geoseries_util, and several fixes in tests.

An xfail was added in `test_read_file_columns_geometry` because a column with datetimes with a mix of values with and without time zone offsets gives a error. Fix needed in pyogrio.

Issue opened to remove the xfail once pyogrio has been fixed: #802 