### PR TITLE
BUG: in some rare cases, difference gives incorrect result 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix `dissolve` on an input file without crs (#794)
 - Fix writing csv files on non-UTF8 systems (#797)
+- Fix incorrect result of difference in some rare cases (#799)
 
 ## 0.11.0 (2025-12-10)
 

--- a/geofileops/util/_geoops_sql.py
+++ b/geofileops/util/_geoops_sql.py
@@ -1225,7 +1225,8 @@ def difference(  # noqa: D417
                 SELECT * FROM (
                 SELECT IFNULL(
                         ( SELECT IFNULL(
-                                    IIF(COUNT(layer2_sub.rowid) = 0,
+                                    IIF(COUNT(layer2_sub.rowid) = 0
+                                            OR ST_Union(layer2_sub.{{input2_geometrycolumn}}) IS NULL,
                                         layer1.{{input1_geometrycolumn}},
                                         ST_CollectionExtract(
                                             ST_difference(
@@ -1276,7 +1277,8 @@ def difference(  # noqa: D417
                         SELECT fid_1 AS layer1_rowid_orig
                                 ,IFNULL(
                                 ( SELECT IFNULL(
-                                            IIF(COUNT(layer2_sub.rowid) = 0,
+                                            IIF(COUNT(layer2_sub.rowid) = 0
+                                                    OR ST_Union(layer2_sub.{{input2_geometrycolumn}}) IS NULL,
                                                 layer1_subdiv.{{input1_subdiv_geometrycolumn}},
                                                 ST_CollectionExtract(
                                                     ST_difference(


### PR DESCRIPTION
`geofileops.difference` in some cases removes polygons entirely even though they only overlap some slivers.

The underlying issue is that in rare cases ST_Union (=GEOS `unaryUnion`) results in an empty geometry, typically when the input geometries are very small/narrow.

In `gfo.difference` all overlapping geometries from input2 are ST_Union'ed before performing the ST_Difference with input1. Hence, for this rare case, the geometry to difference  with becomes empty (or NULL in spatialite). Because ST_difference(..., NULL) returns NULL, the resulting geometry becomes NULL as well. Because the ST_Union problem typically happens with very small or very close    vertices, it is more logical to retain the original input1 polygon rather than having it disappear, which is the new behaviour.

Issue opened in GEOS for the wrong result of unaryUnion: https://github.com/libgeos/geos/issues/1383