### PR TITLE
TST: fix dissolve test for sqlite 3.52.0

### DIFF
--- a/tests/single_layer_operations/test_geoops_dissolve.py
+++ b/tests/single_layer_operations/test_geoops_dissolve.py
@@ -723,7 +723,7 @@ def test_dissolve_polygons_tiles_empty(tmp_path, suffix, nb_parallel):
     bounds = (
         bounds[0] - 1,
         bounds[1] - 1,
-        bounds[2] + 1 + width,
+        bounds[2] + 2 + width,
         bounds[3] + 1,
     )
     tiles_gdf = gpd.GeoDataFrame(


### PR DESCRIPTION
Starting with sqlite 3.52.0, `test_dissolve_polygons_tiles_empty` started failing for the .gpkg tests.

The `dissolve` with predefined tiles to be retained in the output resulted in an extra multipolygon in the output (5 instead of 4). The extra polygon was a sliver on the right-edge of the test data... because apparently the edge of the tile was now right 1e-20 left of the polygon boundary instead of to the right of it... resulting in an extra polygon.

Widening the input bounds used to create the tile-grid to be used when dissolving by 1 meter moved the tile border enough to the right to fix the issue.

Theory why this change occurs: in sqlite 3.52.0, when converting floating points from text to floats, now 17 decimal places are retained instead of 15 before. Maybe this results in the tile edges moving slightly when saved/read from the tiles gpkg? https://www.sqlite.org/releaselog/3_52_0.html