### PR TITLE
BUG: Permission denied error when using add_columns with output_path on read-only files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.11.2
+
+### Bugs fixed
+
+- Fix `permission denied` error when using add_columns with output_path
+  on read-only files (#813)
+
 ## 0.11.1 (2026-02-22)
 
 ### Improvements

--- a/geofileops/fileops.py
+++ b/geofileops/fileops.py
@@ -1295,7 +1295,7 @@ def add_columns(
         if tmp_dir is not None:
             # Add columns to tmp copy
             output_tmp_path = tmp_dir / Path(path).name
-            copy(path, output_tmp_path)
+            copy(path, output_tmp_path, keep_permissions=False)
         else:
             # Add columns in place
             output_tmp_path = path  # type: ignore[assignment]

--- a/tests/general_file_layer_operations/test_geofile.py
+++ b/tests/general_file_layer_operations/test_geofile.py
@@ -433,6 +433,59 @@ def test_add_columns_output_layer(
         )
 
 
+@pytest.mark.parametrize(
+    "testfile, suffix, output_path, exp_permission_error",
+    [
+        ("polygon-parcel", ".shp", "output_file", False),
+        ("polygon-parcel", ".shp", None, True),
+        ("polygon-parcel", ".gpkg", "output_file", False),
+        ("polygon-parcel", ".gpkg", None, True),
+    ],
+)
+def test_add_columns_readonly_input(
+    tmp_path, testfile, suffix, output_path, exp_permission_error
+):
+    """Test that add_columns works when the input file is read-only."""
+    test_path = test_helper.get_testfile(testfile, dst_dir=tmp_path, suffix=suffix)
+
+    # Make the file read-only
+    Path(test_path).chmod(0o444)
+
+    # Columns to add
+    new_columns = [("new_column", "string")]
+
+    # Test
+    if exp_permission_error:
+        handler = pytest.raises(RuntimeError, match="Permission denied")
+    else:
+        handler = nullcontext()
+
+    with handler:
+        if output_path is not None:
+            output_path = tmp_path / f"output_file{suffix}"
+        gfo.add_columns(
+            test_path,
+            new_columns=new_columns,
+            output_path=output_path,
+        )
+
+        # Check if columns were added
+        if output_path is None:
+            output_path = test_path
+        output_layerinfo = gfo.get_layerinfo(
+            path=output_path, layer=gfo.get_default_layer(output_path)
+        )
+        for col_name, col_type in new_columns:
+            assert col_name in output_layerinfo.columns
+            exp_type = (
+                col_type if isinstance(col_type, str) else col_type.value
+            ).lower()
+            output_type = output_layerinfo.columns[col_name].gdal_type.lower()
+            assert output_type.startswith(exp_type), (
+                f"Column {col_name}: expected {exp_type}, got {output_type}"
+            )
+
+
 def test_append_to(tmp_path):
     """Test the append_to function.
 

--- a/tests/general_file_layer_operations/test_geofile.py
+++ b/tests/general_file_layer_operations/test_geofile.py
@@ -449,7 +449,7 @@ def test_add_columns_readonly_input(
     test_path = test_helper.get_testfile(testfile, dst_dir=tmp_path, suffix=suffix)
 
     # Make the file read-only
-    test_helper.set_readonly(test_path, True)
+    test_helper.set_read_only(test_path, True)
 
     # Columns to add
     new_columns = [("new_column", "string")]

--- a/tests/general_file_layer_operations/test_geofile.py
+++ b/tests/general_file_layer_operations/test_geofile.py
@@ -449,7 +449,7 @@ def test_add_columns_readonly_input(
     test_path = test_helper.get_testfile(testfile, dst_dir=tmp_path, suffix=suffix)
 
     # Make the file read-only
-    Path(test_path).chmod(0o444)
+    test_helper.set_readonly(test_path, True)
 
     # Columns to add
     new_columns = [("new_column", "string")]


### PR DESCRIPTION
When the add_columns function is used with an output_path parameter, the original file is copied to a temporary location. The keep_permissions option parameter is set to false

resolves: #813 